### PR TITLE
AIOS-CLEAN-01: pipeline hygiene runbook + legacy label cleanup

### DIFF
--- a/docs/aios-issues-runbook.md
+++ b/docs/aios-issues-runbook.md
@@ -88,15 +88,17 @@ Issues GitHub sao espelhadas (read-only) para o Company Brain via adapter
 GitHub Issues. Por issue criada/fechada/relabelada, esperar:
 
 - `Source` `AIOS GitHub Issues active roadmap` (reusado, nao recriado).
-- `Artifact` `github_issue` por issue, com `raw_ref` apontando para a URL HTML
-  do GitHub e provenance `adapter:github_issues_sync`.
-- `WorkItem` canonico com `external_provider=github`, `external_id=<issue
-  number>`, `external_url`, status `open|closed`, owner derivado de assignees,
-  labels e milestone copiados do GitHub.
+- `Artifact` `github_issue` por issue, com `rawRef` apontando para a URL HTML
+  do GitHub e provenance `adapter:github_issues`.
+- `WorkItem` canonico com `externalProvider=github`,
+  `externalId=antonio-mello-ai/crewdock#<issue number>`, `externalUrl`,
+  status `triage` para issue aberta ou `done` para issue fechada, owner
+  derivado de assignees, labels e milestone copiados do GitHub.
+- WorkItem provenance: `adapter:github_issues:work_item`.
 
 Adapter:
 
-- API: `POST /api/company-brain/sources/github-issues/sync`.
+- API: `POST /api/company-brain/adapters/github/issues/sync`.
 - MCP tool: `mcp__aios__sync_company_brain_github_issues`.
 
 Modo: read-only. Nao escreve em GitHub. Issues que mudam de label/state apos o
@@ -105,7 +107,7 @@ ultimo sync sao reconciliadas no proximo sync.
 Limites:
 
 - Sync nao apaga `WorkItem` quando a issue some do filtro. Ha dedupe por
-  `external_id`; mudancas chegam como reconciliacao.
+  `externalId`; mudancas chegam como reconciliacao.
 - Issues com prefixo `AIOS-` viram WorkItems sob prioridade do roadmap quando
   associacao manual existe; demais ficam visiveis em Adoption Dashboard com gap
   `no_priority_or_goal`.
@@ -120,7 +122,7 @@ Limites:
 2. Identificar a proxima issue:
    - Listar issues abertas da milestone ativa via `gh issue list --milestone
      "AIOS Execution Loop v0" --state open` ordenadas por numero.
-   - Ou ler WorkItems com `external_provider=github` no Company Brain summary.
+   - Ou ler WorkItems com `externalProvider=github` no Company Brain summary.
    - Ou ler `Adoption Dashboard` para ver gaps por source.
 3. Validar que a issue tem `Acceptance Criteria` e `Constraints` legiveis. Se
    nao tiver, abrir comentario sugestivo (HITL) em vez de implementar; nao
@@ -156,7 +158,7 @@ Limites:
 5. Preencher template (Context/Goal/Scope/Acceptance/Constraints).
 6. Apos abrir, rodar sync read-only para criar `Artifact`/`WorkItem`:
    - `mcp__aios__sync_company_brain_github_issues` ou
-   - `POST /api/company-brain/sources/github-issues/sync`.
+   - `POST /api/company-brain/adapters/github/issues/sync`.
 
 ## Mutation policy
 

--- a/docs/aios-issues-runbook.md
+++ b/docs/aios-issues-runbook.md
@@ -1,0 +1,185 @@
+# AIOS GitHub Issues Runbook
+
+Convencoes para abrir, classificar e consumir GitHub Issues como fila ativa do
+AIOS / Company Brain. Aplica-se ao repo `antonio-mello-ai/crewdock`.
+
+Issues GitHub sao a fila de trabalho humano-legivel do AIOS. Cada issue ativa
+deve ter um WorkItem espelho no Company Brain (read-only) para que agentes
+consigam recomendar/consumir sem ler chat history.
+
+Source de verdade do produto: `corp/docs/action/aios-product-roadmap.md`.
+Boundary local: `docs/company-brain-direction.md`. Backlog implementacional:
+`docs/backlog.md`.
+
+## Estado da fila
+
+- Milestone ativa: `AIOS Execution Loop v0` (number=3).
+- Active queue: issues abertas com label `aios` + milestone ativa.
+- Legacy queue: issues fechadas marcadas com pelo menos uma de
+  `legacy-runtime`, `runtime-admin`, `icebox` ou `superseded`. Permanecem
+  pesquisaveis mas ficam fora do roadmap atual.
+
+## Labels canonicas
+
+Roadmap AIOS / Company Brain:
+
+| Label | Quando usar |
+|-------|-------------|
+| `aios` | Qualquer trabalho do roadmap AIOS / Company Brain. |
+| `company-brain` | Tocar kernel horizontal (artifact, signal, work item, guidance, agent context, autoimprove). |
+| `execution-loop` | Loop work item -> agent session -> result intake -> QA. |
+| `product-surface` | UI/navegacao do produto (`/company-brain`, `/company-brain/operating`). |
+| `cleanup` | Higiene de produto/repo, separacao de escopo. |
+| `dogfood` | Trabalho validado/dirigido por dogfood real. |
+
+Classificacao de fechado/legado:
+
+| Label | Quando usar |
+|-------|-------------|
+| `legacy-runtime` | Item CrewDock anterior ao AIOS. Fora do roadmap atual mas mantido para historico. |
+| `runtime-admin` | Superficie de runtime/admin herdada do CrewDock (Console, Terminal, Jobs, Schedules, etc.). |
+| `icebox` | Preservado para depois. Nao esta no roadmap ativo. |
+| `superseded` | Substituido por direcionamento AIOS / Company Brain mais novo. |
+
+Categorizacao tradicional ainda usada quando aplicavel: `bug`, `enhancement`,
+`security`, `scalability`, `best-practices`, `documentation`.
+
+## Convencao de titulo
+
+Issues do roadmap AIOS usam prefixo:
+
+- `AIOS-CLEAN-NN` para limpeza de pipeline / produto / repo.
+- `AIOS-EXEC-NN` para execution loop (command center, work item flow, agent
+  launcher, result intake, project pipeline).
+- `AIOS-OPS-NN` para operacao de Company Brain (cadence, briefing, gate
+  closure, source health) quando precisar virar issue formal alem do backlog.
+
+Exemplos atuais:
+
+- `#26 AIOS-CLEAN-01: AIOS GitHub Pipeline Hygiene`
+- `#27 AIOS-EXEC-01: Execution Command Center v0`
+- `#28 AIOS-EXEC-02: WorkItem to GitHub Issue Flow`
+
+Issues legacy (#1 a #24, milestones `v1.4.0`, `v1.5.0`) usavam prefixos
+diferentes (`sec:`, `perf:`, `ops:`, `test:`). Manter como esta; nao renomear.
+
+## Estrutura recomendada do corpo
+
+```markdown
+## Context
+<por que essa issue existe; link com WorkItem/guidance no Company Brain quando relevante>
+
+## Goal
+<resultado esperado em uma frase curta>
+
+## Scope
+- <bullets do que entra>
+
+## Acceptance Criteria
+- <conditions of done verificaveis (build, sync, doc, dogfood)>
+
+## Constraints
+- <bloqueios explicitos: risk class, writeback proibido, secrets, deploy>
+```
+
+## Mapping issue -> Company Brain WorkItem
+
+Issues GitHub sao espelhadas (read-only) para o Company Brain via adapter
+GitHub Issues. Por issue criada/fechada/relabelada, esperar:
+
+- `Source` `AIOS GitHub Issues active roadmap` (reusado, nao recriado).
+- `Artifact` `github_issue` por issue, com `raw_ref` apontando para a URL HTML
+  do GitHub e provenance `adapter:github_issues_sync`.
+- `WorkItem` canonico com `external_provider=github`, `external_id=<issue
+  number>`, `external_url`, status `open|closed`, owner derivado de assignees,
+  labels e milestone copiados do GitHub.
+
+Adapter:
+
+- API: `POST /api/company-brain/sources/github-issues/sync`.
+- MCP tool: `mcp__aios__sync_company_brain_github_issues`.
+
+Modo: read-only. Nao escreve em GitHub. Issues que mudam de label/state apos o
+ultimo sync sao reconciliadas no proximo sync.
+
+Limites:
+
+- Sync nao apaga `WorkItem` quando a issue some do filtro. Ha dedupe por
+  `external_id`; mudancas chegam como reconciliacao.
+- Issues com prefixo `AIOS-` viram WorkItems sob prioridade do roadmap quando
+  associacao manual existe; demais ficam visiveis em Adoption Dashboard com gap
+  `no_priority_or_goal`.
+
+## Como consumir a fila como agente
+
+1. Ler estado do Company Brain antes de tudo:
+   - `mcp__aios__get_company_brain_operating_snapshot`
+   - `mcp__aios__get_company_brain_summary`
+   - `mcp__aios__generate_company_brain_daily_agent_handoff` se a sessao for
+     "diaria/contextual" e nao houver handoff fresco.
+2. Identificar a proxima issue:
+   - Listar issues abertas da milestone ativa via `gh issue list --milestone
+     "AIOS Execution Loop v0" --state open` ordenadas por numero.
+   - Ou ler WorkItems com `external_provider=github` no Company Brain summary.
+   - Ou ler `Adoption Dashboard` para ver gaps por source.
+3. Validar que a issue tem `Acceptance Criteria` e `Constraints` legiveis. Se
+   nao tiver, abrir comentario sugestivo (HITL) em vez de implementar; nao
+   inferir escopo.
+4. Criar branch a partir de `origin/main`:
+   `<aios-issue-key>-<short-slug>` (ex.: `aios-clean-01-pipeline-hygiene`).
+5. Implementar no escopo da issue. Parar antes de:
+   - Writeback externo nao previsto pela issue.
+   - Mudanca de secret/permissao nao listada.
+   - Deploy nao instruido.
+   - Ambiguidade real de produto. Nesse caso, abrir comentario na issue.
+6. Validar antes de commitar:
+   - `git diff --check`
+   - `npx turbo build` se mexer em codigo.
+   - Smoke test relevante para o escopo (ex: `mcp__aios__sync_*` apos mudar
+     adapter).
+7. Commit + PR contra `main`. Titulo do PR usa o prefixo da issue, ex:
+   `AIOS-CLEAN-01: pipeline hygiene runbook + legacy label cleanup`. Linkar a
+   issue na descricao (`Closes #26`).
+8. Registrar resultado em `docs/action/<topic>-<date>.md` quando o trabalho
+   produzir aprendizado durador (cycle dogfood, decisao de produto, friccao
+   nova). Mudancas internas sem aprendizado novo nao precisam.
+
+## Como abrir uma issue AIOS
+
+1. Confirmar que o trabalho esta no roadmap (`corp/docs/action/aios-product-roadmap.md`)
+   ou no backlog deste repo (`docs/backlog.md`). Se nao estiver, abrir a
+   discussao ali primeiro; issues GitHub sao a saida operacional, nao a fonte.
+2. Escolher prefixo de titulo (`AIOS-CLEAN-NN`, `AIOS-EXEC-NN`, `AIOS-OPS-NN`)
+   incrementando o ultimo numero usado.
+3. Aplicar labels `aios` + outras pertinentes.
+4. Atribuir milestone `AIOS Execution Loop v0` enquanto a frente estiver ativa.
+5. Preencher template (Context/Goal/Scope/Acceptance/Constraints).
+6. Apos abrir, rodar sync read-only para criar `Artifact`/`WorkItem`:
+   - `mcp__aios__sync_company_brain_github_issues` ou
+   - `POST /api/company-brain/sources/github-issues/sync`.
+
+## Mutation policy
+
+- Sessoes humano-com-claude podem aplicar labels e fechar issues
+  manualmente como parte do trabalho documentado em uma issue ativa.
+- Watchers AIOS nao podem mutar issues sem `ExternalActionProposal` aprovada,
+  preview registrado e executor real publicado. Hoje executor real existe
+  apenas para `github_comment` (Risk B) e `github_label` (Risk B,
+  preview-required, allowlist), ambos fora do escopo de Pipeline Hygiene.
+- Acoes bloqueadas por default no AIOS: close, reopen, merge, deploy, delete,
+  permissions, secrets, customer repos. Ver `docs/writeback-policy-matrix.md`
+  para a matriz canonica.
+
+## Reconciliacao com `docs/backlog.md`
+
+`docs/backlog.md` lista os cortes de implementacao com status incremental
+(`Status XXX v0 em YYYY-MM-DD: ...`). Ao concluir uma issue AIOS:
+
+1. Marcar o checkbox correspondente no backlog.
+2. Adicionar uma linha `Status` curta com o resumo do corte.
+3. Mencionar o numero da issue no commit (`Closes #NN`) para fechar
+   automaticamente apos merge.
+
+Quando uma issue eh fechada como `not planned`, registrar a decisao em uma
+linha `Status` ou no doc de acao do dia, e aplicar `superseded`/`icebox`
+conforme apropriado.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -157,7 +157,11 @@ Status Production Operating Loop v0 em 2026-05-07: implementado e deployado runn
 
 Status AIOS GitHub Roadmap Reset em 2026-05-07: issues antigas `#1` a `#6` foram triadas como legado/icebox/superseded e fechadas como `not planned`, sem apagar contexto. Criada milestone `AIOS Execution Loop v0`, labels de produto/runtime e fila ativa `#25` a `#31`: `AIOS-CLEAN-00`, `AIOS-CLEAN-01`, `AIOS-EXEC-01` a `AIOS-EXEC-05`. Sync read-only de GitHub Issues em producao criou Source `AIOS GitHub Issues active roadmap` e WorkItems canonicos para as 7 issues. Registro em `docs/action/aios-github-roadmap-reset-2026-05-07.md`.
 
-Proximo corte planejado: consumir `#25 AIOS-CLEAN-00: Product Surface Split` via branch/PR, separando AIOS produto de Runtime Admin legado antes de iniciar features do Execution Command Center. Continuar automaticamente apenas para read-only/audit/docs/UI/MCP/dogfood; parar antes de novo executor real, novo alvo externo, secrets/permissoes ou qualquer mutacao fora da policy aprovada.
+Status AIOS-CLEAN-00 Product Surface Split em 2026-05-07: issue `#25` fechada com `/runtime` separado da entrada AIOS principal e Runtime Admin (Console/Terminal/Jobs/Schedules/Costs/Inbox/Settings) reagrupado fora do produto AIOS.
+
+Status AIOS-CLEAN-01 GitHub Pipeline Hygiene em 2026-05-07: issue `#26` consumida. Criado `docs/aios-issues-runbook.md` com convencoes de label/title/body, mapping issue->WorkItem, fluxo de consumo por agente e mutation policy. Issues fechadas legacy (`#7` a `#24`, waves de security/perf pre-AIOS) receberam label `legacy-runtime` para ficarem fora do roadmap atual mas pesquisaveis. Sync read-only do adapter `mcp__aios__sync_company_brain_github_issues` reconciliou `Source` `AIOS GitHub Issues active roadmap` e `WorkItems` para a fila ativa.
+
+Proximo corte planejado: consumir `#27 AIOS-EXEC-01: Execution Command Center v0` ou outra issue aberta da milestone `AIOS Execution Loop v0`. Continuar automaticamente apenas para read-only/audit/docs/UI/MCP/dogfood; parar antes de novo executor real, novo alvo externo, secrets/permissoes ou qualquer mutacao fora da policy aprovada.
 
 - [x] **Company Brain schema v0** — adicionar objetos horizontais no daemon: `Source`, `Artifact`, `StrategicPriority`, `Decision`, `Signal`, `WorkItem`, `WorkflowBlueprint`, `WorkflowRun`, `AlignmentFinding`, `GuidanceItem`, `AgentContext` e `ImprovementProposal`
 - [x] **Source registry + raw artifact store** — guardar artifacts com `source`, `raw_ref`, author, timestamp, hash, visibility e provenance
@@ -170,8 +174,8 @@ Proximo corte planejado: consumir `#25 AIOS-CLEAN-00: Product Surface Split` via
 - [x] **Demo/Readiness Cleanup v0** — reduzir friccoes do pack com proposals internas v0.2, Source Health menos ruidoso, alias top-level de replay, reconhecimento do design-partner pack e campo canonico `artifactType`
 - [x] **Operating Cycle Friction Closure v0** — corrigir briefing pos-cadence, `runs[].artifactId`, status agregado de Gate Closure/Operating Snapshot e semantica de Core Readiness antes de deployar o ciclo diario real
 - [x] **Production Operating Loop v0** — runner recorrente interno no daemon para executar watchers read-only due/stale sem sessao interativa aberta, com env config, lock, provenance, API/UI/MCP e dogfood local
-- [ ] **AIOS-CLEAN-00 Product Surface Split** — fazer AIOS Operating ser a entrada principal, preservar runtime antigo em `/runtime` e agrupar Console/Terminal/Jobs/Schedules/Costs/Inbox/Settings como Runtime Admin
-- [ ] **AIOS-CLEAN-01 GitHub Pipeline Hygiene** — manter issues GitHub como fila limpa e sincronizada ao Company Brain
+- [x] **AIOS-CLEAN-00 Product Surface Split** — fazer AIOS Operating ser a entrada principal, preservar runtime antigo em `/runtime` e agrupar Console/Terminal/Jobs/Schedules/Costs/Inbox/Settings como Runtime Admin
+- [x] **AIOS-CLEAN-01 GitHub Pipeline Hygiene** — manter issues GitHub como fila limpa e sincronizada ao Company Brain
 - [ ] **AIOS-EXEC-01 Execution Command Center v0** — recomendar proximo WorkItem e gerar prompt acionavel
 - [ ] **AIOS-EXEC-02 WorkItem to GitHub Issue Flow** — criar issue GitHub governada a partir de WorkItem/Guidance
 - [ ] **AIOS-EXEC-03 Agent Session Launcher** — gerar handoff/prompt por WorkItem e agente alvo


### PR DESCRIPTION
## Summary
- Adds `docs/aios-issues-runbook.md` covering label/title/body conventions, issue-to-WorkItem mapping, agent consumption flow and mutation policy.
- Updates `docs/backlog.md`: marks `AIOS-CLEAN-00` and `AIOS-CLEAN-01` as done, adds status lines, and points the next cut at `#27 AIOS-EXEC-01`.
- Applies `legacy-runtime` to closed legacy issues `#7`-`#24` (security/perf hardening waves pre-AIOS) via `gh` so they remain searchable but stay out of the active roadmap.
- Runs read-only `mcp__aios__sync_company_brain_github_issues` against production to reconcile the active queue (`issuesSeen=6`, idempotent).

## Test plan
- [x] `git diff --check` clean.
- [x] `npx turbo build` — 4/4 successful (FULL TURBO cache).
- [x] `gh issue list --milestone "AIOS Execution Loop v0" --state open` returns the active queue `#26`-`#31`.
- [x] Active legacy issues fall under `legacy-runtime`/`runtime-admin`/`icebox`/`superseded` post-cleanup.
- [x] Read-only Company Brain sync reports `Source` `antonio-mello-ai/crewdock GitHub Issues` healthy with `issuesSeen=6`.

Closes #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)