### PR TITLE
feat: idempotent workspace remove with before/after snapshot

### DIFF
--- a/packages/daemon/src/routes/company-brain.ts
+++ b/packages/daemon/src/routes/company-brain.ts
@@ -14821,10 +14821,43 @@ app.post("/agent-runs/:id/workspace/remove", async (c) => {
       return c.json({ error: "not_found", message: "agent run not found" }, 404);
     }
     const summary = computeWorkspaceCleanupSummary({ agentRun: run });
+    const worktreeListedBefore = summary.worktreeListed;
     const blockReasons: string[] = [];
+
+    // Idempotent path: workspace already removed
     if (!summary.workspaceExists) {
-      blockReasons.push("workspace_missing");
+      const noopAuditTrail = appendAgentRunAuditEntry(run.auditTrail ?? [], {
+        actor: body.actor,
+        event: "agent_run_workspace_remove_noop",
+        note: body.rationale,
+        metadata: {
+          reason: "workspace_already_removed",
+          targetPath: summary.workspacePath,
+        },
+      });
+      db.update(cbAgentRuns)
+        .set({
+          workspaceRef: run.workspaceRef ? null : run.workspaceRef,
+          auditTrail: noopAuditTrail,
+          updatedAt: now(),
+        } as never)
+        .where(eq(cbAgentRuns.id, id))
+        .run();
+      const noopResponse: RemoveWorkspaceResponse = {
+        generatedAt: now(),
+        agentRunId: id,
+        performed: false,
+        removedPath: null,
+        worktreeRemoved: false,
+        worktreeListedBefore: false,
+        worktreeListedAfter: false,
+        noopAlreadyRemoved: true,
+        commandSummary: "noop: workspace already removed",
+        blockReasons: ["workspace_already_removed"],
+      };
+      return c.json({ data: noopResponse });
     }
+
     if (summary.risks.some((r) => r.kind === "path_outside_root")) {
       blockReasons.push("path_outside_root");
     }
@@ -14844,23 +14877,44 @@ app.post("/agent-runs/:id/workspace/remove", async (c) => {
         performed: false,
         removedPath: null,
         worktreeRemoved: false,
+        worktreeListedBefore,
+        worktreeListedAfter: worktreeListedBefore,
+        noopAlreadyRemoved: false,
+        commandSummary: null,
         blockReasons,
       };
       return c.json({ data: blockedResponse }, 400);
     }
     let worktreeRemoved = false;
-    if (summary.worktreeListed) {
-      const wtRemove = spawnSync("git", ["worktree", "remove", "--force", summary.workspacePath], {
-        encoding: "utf-8",
-      });
-      if (wtRemove.status === 0) worktreeRemoved = true;
+    let commandSummary: string | null = null;
+    if (worktreeListedBefore) {
+      const wtRemove = spawnSync(
+        "git",
+        ["worktree", "remove", "--force", summary.workspacePath],
+        { encoding: "utf-8" }
+      );
+      if (wtRemove.status === 0) {
+        worktreeRemoved = true;
+        commandSummary = `git worktree remove --force OK; rmSync(recursive)`;
+      } else {
+        commandSummary = `git worktree remove --force FAILED (status=${wtRemove.status}, stderr=${(wtRemove.stderr ?? "").trim().slice(0, 200)}); rmSync(recursive) fallback`;
+      }
+    } else {
+      commandSummary = `worktree not listed; rmSync(recursive) only`;
     }
     rmSync(summary.workspacePath, { recursive: true, force: true });
+    const worktreeListedAfter = workspaceListed(summary.workspacePath);
     const auditTrail = appendAgentRunAuditEntry(run.auditTrail ?? [], {
       actor: body.actor,
       event: "agent_run_workspace_removed",
       note: body.rationale,
-      metadata: { removedPath: summary.workspacePath, worktreeRemoved },
+      metadata: {
+        removedPath: summary.workspacePath,
+        worktreeRemoved,
+        worktreeListedBefore,
+        worktreeListedAfter,
+        commandSummary,
+      },
     });
     db.update(cbAgentRuns)
       .set({
@@ -14876,6 +14930,10 @@ app.post("/agent-runs/:id/workspace/remove", async (c) => {
       performed: true,
       removedPath: summary.workspacePath,
       worktreeRemoved,
+      worktreeListedBefore,
+      worktreeListedAfter,
+      noopAlreadyRemoved: false,
+      commandSummary,
       blockReasons: [],
     };
     return c.json({ data: response });

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1213,6 +1213,10 @@ export interface RemoveWorkspaceResponse {
   performed: boolean;
   removedPath: string | null;
   worktreeRemoved: boolean;
+  worktreeListedBefore: boolean;
+  worktreeListedAfter: boolean;
+  noopAlreadyRemoved: boolean;
+  commandSummary: string | null;
   blockReasons: string[];
 }
 


### PR DESCRIPTION
## Summary

Closes #78

Refines `/api/company-brain/agent-runs/:id/workspace/remove` so the AIOS-RUN-17 cleanup gate is safe to retry and produces a richer audit trail.

- Idempotent path: when the workspace already no longer exists, the endpoint now responds with `200` and `noopAlreadyRemoved=true` plus a dedicated `agent_run_workspace_remove_noop` audit entry, instead of returning a generic `400 workspace_missing`. Retries from the dogfood loop stop looking like failures.
- Before/after snapshot: response now includes `worktreeListedBefore` (whether `git worktree list` had the path before remove) and `worktreeListedAfter` (re-check after `rmSync`). Operators can see whether `git worktree remove --force` actually deregistered the worktree, or if rmSync alone was needed.
- `commandSummary` field describes the actions taken (`git worktree remove --force OK; rmSync(recursive)`, `worktree not listed; rmSync(recursive) only`, etc.) so the operations console doesn't need to scrape the daemon log.
- Audit trail now records `worktreeListedBefore`, `worktreeListedAfter`, and `commandSummary` alongside the existing actor, rationale and `removedPath` metadata.
- Block paths (`path_outside_root`, `agent_run_active`, `workspace_dirty`, `confirmation_token_mismatch`) still return `400` with `worktreeListedBefore` populated for diagnosis.

## Test plan

- [x] `npx turbo build` (daemon + shared types compile clean)
- [x] Logic walkthrough: noop early-return preserves audit + clears stale `workspaceRef`; happy path captures before/after; block path returns 400 with snapshot
- [ ] Production smoke after deploy: re-run remove on already-cleaned workspace and confirm `noopAlreadyRemoved=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)