### PR TITLE
feat: operating loop queued-run suggester observe-only

### DIFF
--- a/packages/daemon/src/db/client.ts
+++ b/packages/daemon/src/db/client.ts
@@ -620,6 +620,25 @@ CREATE INDEX IF NOT EXISTS idx_cb_agent_runs_work_item ON cb_agent_runs(work_ite
 CREATE INDEX IF NOT EXISTS idx_cb_agent_runs_status ON cb_agent_runs(status);
 CREATE INDEX IF NOT EXISTS idx_cb_agent_runs_claim_state ON cb_agent_runs(claim_state);
 CREATE INDEX IF NOT EXISTS idx_cb_agent_runs_runner_type ON cb_agent_runs(runner_type);
+
+CREATE TABLE IF NOT EXISTS cb_agent_run_suggestions (
+  id TEXT PRIMARY KEY,
+  work_item_id TEXT NOT NULL,
+  runner_type TEXT NOT NULL DEFAULT 'manual',
+  signature TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active',
+  rationale TEXT NOT NULL,
+  policy_decision TEXT NOT NULL,
+  generated_from TEXT NOT NULL,
+  dismiss_reason TEXT,
+  dismissed_by TEXT,
+  dismissed_at INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_cb_agent_run_suggestions_signature ON cb_agent_run_suggestions(signature);
+CREATE INDEX IF NOT EXISTS idx_cb_agent_run_suggestions_work_item ON cb_agent_run_suggestions(work_item_id);
+CREATE INDEX IF NOT EXISTS idx_cb_agent_run_suggestions_status ON cb_agent_run_suggestions(status);
 `;
 
 let dbInstance: ReturnType<typeof drizzle> | null = null;

--- a/packages/daemon/src/db/schema.ts
+++ b/packages/daemon/src/db/schema.ts
@@ -699,6 +699,42 @@ export const cbWatcherRuns = sqliteTable("cb_watcher_runs", {
   updatedAt: integer("updated_at", { mode: "number" }).notNull(),
 });
 
+export const cbAgentRunSuggestions = sqliteTable("cb_agent_run_suggestions", {
+  id: text("id").primaryKey(),
+  workItemId: text("work_item_id").notNull(),
+  runnerType: text("runner_type")
+    .$type<AgentRunRunnerType>()
+    .notNull()
+    .default("manual"),
+  signature: text("signature").notNull(),
+  status: text("status", {
+    enum: ["active", "dismissed", "superseded"],
+  })
+    .notNull()
+    .default("active"),
+  rationale: text("rationale").notNull(),
+  policyDecision: text("policy_decision", { mode: "json" })
+    .$type<Record<string, unknown>>()
+    .notNull(),
+  generatedFrom: text("generated_from", { mode: "json" })
+    .$type<{
+      nextWorkRank: number;
+      nextWorkSource: string;
+      workItemTitle: string;
+      workItemArea: CompanyBrainArea;
+      suggestedAction: string;
+      sourceIssueRef: string | null;
+      operatingLoopScheduleId: string | null;
+      operatingLoopScheduledAt: number | null;
+    }>()
+    .notNull(),
+  dismissReason: text("dismiss_reason"),
+  dismissedBy: text("dismissed_by"),
+  dismissedAt: integer("dismissed_at", { mode: "number" }),
+  createdAt: integer("created_at", { mode: "number" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "number" }).notNull(),
+});
+
 export const cbAgentRuns = sqliteTable("cb_agent_runs", {
   id: text("id").primaryKey(),
   workItemId: text("work_item_id"),

--- a/packages/daemon/src/routes/company-brain.ts
+++ b/packages/daemon/src/routes/company-brain.ts
@@ -19,7 +19,7 @@ import { homedir } from "node:os";
 import { basename, relative, resolve } from "node:path";
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import type {
   ActionPolicy,
@@ -86,7 +86,13 @@ import type {
   AgentRunListResponse,
   AgentRunRunnerType,
   AgentRunStatus,
+  AgentRunSuggestion,
+  AgentRunSuggestionGeneratedFrom,
+  AgentRunSuggestionStatus,
   AgentRunSummary,
+  DismissAgentRunSuggestionRequest,
+  DismissAgentRunSuggestionResponse,
+  ListAgentRunSuggestionsResponse,
   CreateAgentRunRequest,
   UpdateAgentRunRequest,
   DecomposeOperatingGoalRequest,
@@ -211,6 +217,7 @@ import {
   cbMilestones,
   cbSignals,
   cbAgentRuns,
+  cbAgentRunSuggestions,
   cbSources,
   cbStrategicPriorities,
   cbStrategyTradeoffs,
@@ -5775,6 +5782,13 @@ function buildOperatingSnapshot(
           : "healthy";
   const summary = `${totals.readyCount}/${totals.cardCount} operating cards ready; ${totals.attentionCount} attention; ${totals.criticalCount} critical; ${totals.errorCount} errors; ${totals.missingCount} missing.`;
 
+  let agentRunSuggestions: AgentRunSuggestion[] = [];
+  try {
+    agentRunSuggestions = listAgentRunSuggestions({ status: "active" }).suggestions.slice(0, 10);
+  } catch {
+    agentRunSuggestions = [];
+  }
+
   return {
     generatedAt,
     overallStatus,
@@ -5789,6 +5803,7 @@ function buildOperatingSnapshot(
     sourceHealthReport,
     timeline,
     recentEvents: timeline.events.slice(0, 8),
+    agentRunSuggestions,
   };
 }
 
@@ -17181,6 +17196,20 @@ export async function runCompanyBrainOperatingCadence(
   }
 
   const operatingCadence = buildOperatingCadence(listAll());
+
+  // Observe-only: generate AgentRun suggestions for next-work without auto-dispatch.
+  try {
+    generateAgentRunSuggestionsForOperatingLoop({
+      scheduleId,
+      scheduledAt,
+    });
+  } catch (err) {
+    console.error(
+      "[company-brain] generateAgentRunSuggestionsForOperatingLoop failed",
+      err
+    );
+  }
+
   const response: RunOperatingCadenceResponse = {
     scheduleId,
     scheduledAt,
@@ -17192,6 +17221,285 @@ export async function runCompanyBrainOperatingCadence(
   };
   return response;
 }
+
+function buildAgentRunSuggestionSignature(args: {
+  workItemId: string;
+  runnerType: AgentRunRunnerType;
+  policyDecision: RunnerPolicyDecision;
+  satisfiedGates: string[];
+  blockedGates: string[];
+  workItemTitle: string;
+  workItemStatus: string;
+  workItemUpdatedAt: number;
+}): string {
+  const payload = JSON.stringify({
+    workItemId: args.workItemId,
+    runnerType: args.runnerType,
+    policyDecision: args.policyDecision,
+    satisfiedGates: [...args.satisfiedGates].sort(),
+    blockedGates: [...args.blockedGates].sort(),
+    workItemTitle: args.workItemTitle,
+    workItemStatus: args.workItemStatus,
+    workItemUpdatedAt: args.workItemUpdatedAt,
+  });
+  return createHash("sha256").update(payload).digest("hex");
+}
+
+function generateAgentRunSuggestionsForOperatingLoop(args: {
+  scheduleId: string | null;
+  scheduledAt: number | null;
+}): void {
+  const db = getDb();
+  const data = listAll();
+  const nextWork = buildNextWork(data);
+  if (!nextWork.recommended) return;
+
+  const recommended = nextWork.recommended;
+  const workItem = (data.workItems as WorkItem[]).find(
+    (item) => item.id === recommended.workItem.id
+  );
+  if (!workItem) return;
+
+  // Build a synthetic AgentRun-shaped object to feed evaluateRunnerPolicy.
+  // No DB row is created; this is preview-only.
+  const workflow = loadWorkflowFromRepoRoot();
+  const repo = workflow.config.tracker.repo ?? null;
+
+  const syntheticRun = {
+    id: `suggestion-${workItem.id}`,
+    workItemId: workItem.id,
+    workflowRunId: null,
+    agentContextId: null,
+    sourceId: workItem.sourceId ?? null,
+    repo,
+    branch: null,
+    workspaceRef: null,
+    runnerType: "claude_code" as AgentRunRunnerType,
+    status: "queued" as AgentRunStatus,
+    claimState: "unclaimed" as const,
+    attempt: 0,
+    startedAt: null,
+    finishedAt: null,
+    errorSummary: null,
+    prUrl: null,
+    externalRunRef: null,
+    tokensInput: null,
+    tokensOutput: null,
+    tokensTotal: null,
+    costUsd: null,
+    agentSessionId: null,
+    agentThreadId: null,
+    area: workItem.area,
+    riskClass: workItem.riskClass ?? "B",
+    actionPolicy: "observe_only" as const,
+    visibility: workItem.visibility ?? "internal",
+    pid: null,
+    executionRef: null,
+    lastLogAt: null,
+    lastLogLineCount: null,
+    metadata: null,
+    auditTrail: [],
+    provenance: null,
+    createdAt: now(),
+    updatedAt: now(),
+  } as unknown as typeof cbAgentRuns.$inferSelect;
+
+  let policy: RunnerExecutionPolicy;
+  try {
+    policy = evaluateRunnerPolicy({
+      agentRun: syntheticRun,
+      request: {
+        intent: "real_execution",
+        actor: "operating-loop:suggester",
+        rationale: "preview policy for queued-run suggestion",
+      },
+    });
+  } catch (err) {
+    console.error("[company-brain] evaluateRunnerPolicy failed for suggester", err);
+    return;
+  }
+
+  const satisfiedGates = policy.gates
+    .filter((gate) => gate.status === "passed")
+    .map((gate) => gate.key);
+  const blockedGates = policy.gates
+    .filter((gate) => gate.status === "failed")
+    .map((gate) => gate.key);
+
+  const signature = buildAgentRunSuggestionSignature({
+    workItemId: workItem.id,
+    runnerType: "claude_code",
+    policyDecision: policy.decision,
+    satisfiedGates,
+    blockedGates,
+    workItemTitle: workItem.title,
+    workItemStatus: workItem.status,
+    workItemUpdatedAt: workItem.updatedAt,
+  });
+
+  const existingForSig = db
+    .select()
+    .from(cbAgentRunSuggestions)
+    .where(eq(cbAgentRunSuggestions.signature, signature))
+    .get();
+  if (existingForSig) {
+    // Already recorded (active, dismissed, or superseded). Do not regenerate.
+    return;
+  }
+
+  const rationaleParts: string[] = [];
+  rationaleParts.push(`Top of next-work: "${workItem.title}".`);
+  if (recommended.rationale.length) {
+    rationaleParts.push(...recommended.rationale.slice(0, 2));
+  }
+  rationaleParts.push(
+    `Runner policy decision=${policy.decision}; satisfied=${satisfiedGates.length}; blocked=${blockedGates.length}.`
+  );
+  const rationale = rationaleParts.join(" ").slice(0, 800);
+
+  const generatedFrom: AgentRunSuggestionGeneratedFrom = {
+    nextWorkRank: 1,
+    nextWorkSource: "buildNextWork:recommended",
+    workItemTitle: workItem.title,
+    workItemArea: workItem.area,
+    suggestedAction: `Run supervised AgentRun for ${workItem.externalId ?? workItem.id} via /agent-runs/:id/execute-async after manual review`,
+    sourceIssueRef:
+      workItem.externalProvider === "github" && workItem.externalId
+        ? workItem.externalId
+        : null,
+    operatingLoopScheduleId: args.scheduleId,
+    operatingLoopScheduledAt: args.scheduledAt,
+  };
+
+  // Supersede any existing active rows for this work item before inserting.
+  const priorActive = db
+    .select()
+    .from(cbAgentRunSuggestions)
+    .where(
+      and(
+        eq(cbAgentRunSuggestions.workItemId, workItem.id),
+        eq(cbAgentRunSuggestions.status, "active")
+      )
+    )
+    .all() as AgentRunSuggestion[];
+  for (const prior of priorActive) {
+    db.update(cbAgentRunSuggestions)
+      .set({
+        status: "superseded",
+        updatedAt: now(),
+      } as never)
+      .where(eq(cbAgentRunSuggestions.id, prior.id))
+      .run();
+  }
+
+  const id = nanoid(12);
+  const timestamp = now();
+  const row: AgentRunSuggestion = {
+    id,
+    workItemId: workItem.id,
+    runnerType: "claude_code",
+    signature,
+    status: "active",
+    rationale,
+    policyDecision: policy.decision as unknown as Record<string, unknown>,
+    generatedFrom,
+    dismissReason: null,
+    dismissedBy: null,
+    dismissedAt: null,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+  db.insert(cbAgentRunSuggestions).values(row as never).run();
+}
+
+function listAgentRunSuggestions(args: {
+  status?: AgentRunSuggestionStatus | "all";
+  workItemId?: string;
+}): ListAgentRunSuggestionsResponse {
+  const db = getDb();
+  const all = db.select().from(cbAgentRunSuggestions).all() as AgentRunSuggestion[];
+  const totals = {
+    active: all.filter((row) => row.status === "active").length,
+    dismissed: all.filter((row) => row.status === "dismissed").length,
+    superseded: all.filter((row) => row.status === "superseded").length,
+  };
+  let filtered = all;
+  if (args.status && args.status !== "all") {
+    filtered = filtered.filter((row) => row.status === args.status);
+  } else if (!args.status) {
+    filtered = filtered.filter((row) => row.status === "active");
+  }
+  if (args.workItemId) {
+    filtered = filtered.filter((row) => row.workItemId === args.workItemId);
+  }
+  filtered = [...filtered].sort((a, b) => b.createdAt - a.createdAt);
+  return {
+    generatedAt: now(),
+    suggestions: filtered,
+    totals,
+  };
+}
+
+app.get("/agent-run-suggestions", (c) => {
+  const status = c.req.query("status") as AgentRunSuggestionStatus | "all" | undefined;
+  const workItemId = c.req.query("workItemId") || undefined;
+  const data = listAgentRunSuggestions({ status, workItemId });
+  return c.json({ data });
+});
+
+app.post("/agent-run-suggestions/:id/dismiss", async (c) => {
+  const id = c.req.param("id");
+  const db = getDb();
+  const existing = db
+    .select()
+    .from(cbAgentRunSuggestions)
+    .where(eq(cbAgentRunSuggestions.id, id))
+    .get() as AgentRunSuggestion | undefined;
+  if (!existing) {
+    return c.json({ error: "not_found", message: `agent run suggestion ${id} not found` }, 404);
+  }
+  if (existing.status !== "active") {
+    return c.json(
+      {
+        error: "validation",
+        message: `agent run suggestion ${id} is ${existing.status}; only active suggestions can be dismissed`,
+      },
+      400
+    );
+  }
+  const body = (await c.req
+    .json<DismissAgentRunSuggestionRequest>()
+    .catch(() => ({}))) as DismissAgentRunSuggestionRequest;
+  const actor = body.actor?.trim();
+  const rationale = body.rationale?.trim();
+  if (!actor) {
+    return c.json({ error: "validation", message: "actor is required" }, 400);
+  }
+  if (!rationale) {
+    return c.json({ error: "validation", message: "rationale is required" }, 400);
+  }
+  const timestamp = now();
+  db.update(cbAgentRunSuggestions)
+    .set({
+      status: "dismissed",
+      dismissReason: rationale,
+      dismissedBy: actor,
+      dismissedAt: timestamp,
+      updatedAt: timestamp,
+    } as never)
+    .where(eq(cbAgentRunSuggestions.id, id))
+    .run();
+  const refreshed = db
+    .select()
+    .from(cbAgentRunSuggestions)
+    .where(eq(cbAgentRunSuggestions.id, id))
+    .get() as AgentRunSuggestion;
+  const response: DismissAgentRunSuggestionResponse = {
+    generatedAt: timestamp,
+    suggestion: refreshed,
+  };
+  return c.json({ data: response });
+});
 
 app.get("/gate-closure-ritual", (c) => {
   const data = buildGateClosureRitual(listAll());

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1583,6 +1583,53 @@ server.registerTool(
 );
 
 server.registerTool(
+  "list_company_brain_agent_run_suggestions",
+  {
+    title: "List Company Brain AgentRun suggestions",
+    description:
+      "List queued-run suggestions produced by the Operating Loop suggester. Observe-only: suggestions never auto-dispatch a subprocess.",
+    inputSchema: {
+      status: z.enum(["active", "dismissed", "superseded", "all"]).optional(),
+      workItemId: z.string().optional(),
+    },
+  },
+  async ({ status, workItemId }) => {
+    const params = new URLSearchParams();
+    if (status) params.set("status", status);
+    if (workItemId) params.set("workItemId", workItemId);
+    const suffix = params.toString() ? `?${params.toString()}` : "";
+    const result = await daemonFetch<{ data: unknown }>(
+      `/api/company-brain/agent-run-suggestions${suffix}`
+    );
+    return formatJsonResult(result.data);
+  }
+);
+
+server.registerTool(
+  "dismiss_company_brain_agent_run_suggestion",
+  {
+    title: "Dismiss Company Brain AgentRun suggestion",
+    description:
+      "Mark an active AgentRun suggestion as dismissed. Idempotency: same signature is suppressed until WorkItem state or policy snapshot changes.",
+    inputSchema: {
+      suggestionId: z.string().min(1),
+      actor: z.string().min(1),
+      rationale: z.string().min(1),
+    },
+  },
+  async ({ suggestionId, actor, rationale }) => {
+    const result = await daemonFetch<{ data: unknown }>(
+      `/api/company-brain/agent-run-suggestions/${suggestionId}/dismiss`,
+      {
+        method: "POST",
+        body: JSON.stringify({ actor, rationale }),
+      }
+    );
+    return formatJsonResult(result.data);
+  }
+);
+
+server.registerTool(
   "list_company_brain_external_action_proposals",
   {
     title: "List Company Brain writeback proposals",

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1555,6 +1555,55 @@ export type AgentRunRunnerType =
   | "manual"
   | "other";
 
+export type AgentRunSuggestionStatus = "active" | "dismissed" | "superseded";
+
+export interface AgentRunSuggestionGeneratedFrom {
+  nextWorkRank: number;
+  nextWorkSource: string;
+  workItemTitle: string;
+  workItemArea: CompanyBrainArea;
+  suggestedAction: string;
+  sourceIssueRef: string | null;
+  operatingLoopScheduleId: string | null;
+  operatingLoopScheduledAt: number | null;
+}
+
+export interface AgentRunSuggestion {
+  id: string;
+  workItemId: string;
+  runnerType: AgentRunRunnerType;
+  signature: string;
+  status: AgentRunSuggestionStatus;
+  rationale: string;
+  policyDecision: Record<string, unknown>;
+  generatedFrom: AgentRunSuggestionGeneratedFrom;
+  dismissReason: string | null;
+  dismissedBy: string | null;
+  dismissedAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface ListAgentRunSuggestionsResponse {
+  generatedAt: number;
+  suggestions: AgentRunSuggestion[];
+  totals: {
+    active: number;
+    dismissed: number;
+    superseded: number;
+  };
+}
+
+export interface DismissAgentRunSuggestionRequest {
+  actor: string;
+  rationale: string;
+}
+
+export interface DismissAgentRunSuggestionResponse {
+  generatedAt: number;
+  suggestion: AgentRunSuggestion;
+}
+
 export interface AgentRun {
   id: string;
   workItemId: string | null;
@@ -3619,6 +3668,7 @@ export interface CompanyBrainOperatingSnapshot {
   sourceHealthReport: CompanyBrainSourceHealthReport;
   timeline: CompanyBrainTimeline;
   recentEvents: CompanyBrainTimelineEvent[];
+  agentRunSuggestions: AgentRunSuggestion[];
 }
 
 export type CompanyBrainSavedAuditViewSurface =

--- a/packages/web/src/app/company-brain/agent-runs/page.tsx
+++ b/packages/web/src/app/company-brain/agent-runs/page.tsx
@@ -18,8 +18,10 @@ import {
   useCancelCompanyBrainAgentRun,
   useCompanyBrainAgentRun,
   useCompanyBrainAgentRunLogs,
+  useCompanyBrainAgentRunSuggestions,
   useCompanyBrainAgentRunsList,
   useCompanyBrainAgentRunsSummary,
+  useDismissCompanyBrainAgentRunSuggestion,
   useEvaluateCompanyBrainAgentRunPolicy,
   useExecuteCompanyBrainAgentRun,
 } from "@/hooks/use-api";
@@ -315,12 +317,117 @@ function AgentRunDetail({ runId }: { runId: string }) {
   );
 }
 
+interface AgentRunSuggestionRow {
+  id: string;
+  workItemId: string;
+  runnerType: string;
+  status: "active" | "dismissed" | "superseded";
+  rationale: string;
+  policyDecision: string;
+  generatedFrom: {
+    workItemTitle: string;
+    workItemArea: string;
+    suggestedAction: string;
+    sourceIssueRef: string | null;
+    operatingLoopScheduleId: string | null;
+    operatingLoopScheduledAt: number | null;
+  };
+  createdAt: number;
+}
+
+function SuggestionRow({ suggestion }: { suggestion: AgentRunSuggestionRow }) {
+  const dismissMutation = useDismissCompanyBrainAgentRunSuggestion();
+  const [actor, setActor] = useState("");
+  const [rationale, setRationale] = useState("");
+  const [open, setOpen] = useState(false);
+  return (
+    <li className="border-t border-border first:border-t-0">
+      <div className="flex flex-col gap-2 p-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="secondary" className="text-[10px]">
+              {suggestion.policyDecision}
+            </Badge>
+            <Badge variant="outline" className="text-[10px]">
+              {suggestion.runnerType}
+            </Badge>
+            <Badge variant="outline" className="text-[10px]">
+              {suggestion.generatedFrom.workItemArea}
+            </Badge>
+            {suggestion.generatedFrom.sourceIssueRef ? (
+              <Badge variant="outline" className="text-[10px]">
+                {suggestion.generatedFrom.sourceIssueRef}
+              </Badge>
+            ) : null}
+          </div>
+          <p className="mt-1 text-sm font-medium">{suggestion.generatedFrom.workItemTitle}</p>
+          <p className="mt-1 text-xs text-muted-foreground">{suggestion.rationale}</p>
+          <p className="mt-1 text-[11px] text-muted-foreground">
+            Suggested action: <code className="text-[11px]">{suggestion.generatedFrom.suggestedAction}</code>
+          </p>
+          <p className="mt-1 text-[11px] text-muted-foreground">
+            Created {formatTimeAgo(suggestion.createdAt)} · Observe-only — no subprocess will start.
+          </p>
+        </div>
+        <div className="flex flex-col gap-1 sm:w-64">
+          <Button size="sm" variant="ghost" onClick={() => setOpen(!open)} className="self-end">
+            {open ? "Cancel" : "Dismiss"}
+          </Button>
+          {open ? (
+            <div className="flex flex-col gap-1 rounded border border-border p-2">
+              <input
+                type="text"
+                value={actor}
+                onChange={(e) => setActor(e.target.value)}
+                placeholder="actor"
+                className="w-full rounded border border-input bg-background px-2 py-1 text-xs"
+              />
+              <input
+                type="text"
+                value={rationale}
+                onChange={(e) => setRationale(e.target.value)}
+                placeholder="reason for dismissal"
+                className="w-full rounded border border-input bg-background px-2 py-1 text-xs"
+              />
+              <Button
+                size="sm"
+                variant="destructive"
+                onClick={() =>
+                  dismissMutation.mutate(
+                    { suggestionId: suggestion.id, actor, rationale },
+                    {
+                      onSuccess: () => {
+                        setOpen(false);
+                        setActor("");
+                        setRationale("");
+                      },
+                    }
+                  )
+                }
+                disabled={!actor.trim() || !rationale.trim() || dismissMutation.isPending}
+              >
+                {dismissMutation.isPending ? <Loader2 className="size-3 animate-spin" /> : <Ban className="size-3" />}
+                Confirm dismiss
+              </Button>
+              {dismissMutation.isError ? (
+                <p className="text-[10px] text-destructive">{dismissMutation.error.message}</p>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </li>
+  );
+}
+
 export default function CompanyBrainAgentRunsPage() {
   const { data: summaryRes } = useCompanyBrainAgentRunsSummary();
   const { data: listRes, isLoading } = useCompanyBrainAgentRunsList({ limit: 50 });
+  const { data: suggestionsRes } = useCompanyBrainAgentRunSuggestions("active");
   const [expanded, setExpanded] = useState<string | null>(null);
   const summary = summaryRes?.data as AgentRunSummary | undefined;
   const list = listRes?.data as { items: AgentRunRow[]; total: number } | undefined;
+  const suggestions = (suggestionsRes?.data as { suggestions: AgentRunSuggestionRow[]; totals: { active: number; dismissed: number; superseded: number } } | undefined)?.suggestions ?? [];
 
   return (
     <main className="min-h-screen bg-background p-6 text-foreground">
@@ -373,6 +480,22 @@ export default function CompanyBrainAgentRunsPage() {
               <p className="text-xs text-muted-foreground">stale</p>
               <p className="text-lg font-semibold">{summary.staleCount}</p>
             </article>
+          </section>
+        ) : null}
+
+        {suggestions.length > 0 ? (
+          <section className="rounded-md border border-border">
+            <div className="flex items-center justify-between border-b border-border p-3">
+              <h2 className="text-lg font-semibold">Suggestions ({suggestions.length})</h2>
+              <p className="text-[11px] text-muted-foreground">
+                Operating Loop suggester · observe-only · no auto-dispatch
+              </p>
+            </div>
+            <ul>
+              {suggestions.map((s) => (
+                <SuggestionRow key={s.id} suggestion={s} />
+              ))}
+            </ul>
           </section>
         ) : null}
 

--- a/packages/web/src/hooks/use-api.ts
+++ b/packages/web/src/hooks/use-api.ts
@@ -544,6 +544,34 @@ export function useCompanyBrainOperatingMap() {
   });
 }
 
+export function useCompanyBrainAgentRunSuggestions(status: string = "active") {
+  return useQuery<ApiResponse<unknown>>({
+    queryKey: ["company-brain", "agent-run-suggestions", status],
+    queryFn: () =>
+      api(`/api/company-brain/agent-run-suggestions?status=${status}`),
+    refetchInterval: 10_000,
+  });
+}
+
+export function useDismissCompanyBrainAgentRunSuggestion() {
+  const qc = useQueryClient();
+  return useMutation<ApiResponse<unknown>, Error, {
+    suggestionId: string;
+    actor: string;
+    rationale: string;
+  }>({
+    mutationFn: ({ suggestionId, ...rest }) =>
+      api(`/api/company-brain/agent-run-suggestions/${suggestionId}/dismiss`, {
+        method: "POST",
+        body: JSON.stringify(rest),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["company-brain", "agent-run-suggestions"] });
+      qc.invalidateQueries({ queryKey: ["company-brain", "operating-snapshot"] });
+    },
+  });
+}
+
 export function useCompanyBrainAgentRunsList(filters?: {
   status?: string;
   limit?: number;


### PR DESCRIPTION
## Summary

Closes #79

AIOS-RUN-18: Operating Loop produces auditable AgentRun suggestions for the current next-work without launching any subprocess.

### Schema

New table `cb_agent_run_suggestions`:

| Column | Purpose |
|---|---|
| `id` | nanoid(12) PK |
| `work_item_id` | target WorkItem |
| `runner_type` | always `claude_code` for the suggester |
| `signature` | sha256 of `workItemId + runnerType + policyDecision + satisfiedGates + blockedGates + workItemTitle + status + updatedAt`. Unique index. |
| `status` | `active` / `dismissed` / `superseded` |
| `rationale` | derived from next-work + policy preview |
| `policy_decision` | JSON snapshot of `RunnerPolicyDecision` |
| `generated_from` | JSON: workItem context + operating loop schedule pointer |
| `dismiss_reason`, `dismissed_by`, `dismissed_at` | populated on dismiss |

### Behavior

- `runCompanyBrainOperatingCadence` now calls `generateAgentRunSuggestionsForOperatingLoop` after the cadence runs. Failure of the suggester is logged but does not break cadence runs.
- Suggester builds a synthetic AgentRun-shaped record (no DB row), feeds `evaluateRunnerPolicy` for a preview decision, computes a signature, and inserts a suggestion when no row exists for that signature.
- Prior active rows for the same WorkItem are marked `superseded` when a new signature wins.
- Dismissed signatures are suppressed forever — re-runs do not regenerate them until WorkItem state or policy snapshot changes (which produces a new signature).

### Endpoints

- `GET /api/company-brain/agent-run-suggestions?status=active|dismissed|superseded|all&workItemId=...`
- `POST /api/company-brain/agent-run-suggestions/:id/dismiss` with `{actor, rationale}`. Only `active` rows can be dismissed.

### Surfacing

- `CompanyBrainOperatingSnapshot.agentRunSuggestions: AgentRunSuggestion[]` (top 10 active).
- `/company-brain/agent-runs` web console gains a **Suggestions** section above the Runs table, with WorkItem title, policy decision, rationale, area, source issue ref, observe-only banner and a Dismiss form (actor + rationale required).
- MCP tools: `list_company_brain_agent_run_suggestions`, `dismiss_company_brain_agent_run_suggestion`.

### Constraints honored

- No automatic subprocess launch — manual `/agent-runs/:id/execute(-async)` is still the only path that spawns a child process.
- No external writeback.
- No new secrets, no paid services.
- Idempotency enforced by unique `signature` column.

### Test plan

- [x] `npx turbo build` (daemon + web + shared + mcp-server compile clean).
- [x] Empty list → `totals {active:0, dismissed:0, superseded:0}`.
- [x] After cadence run with one open WorkItem → 1 active suggestion with rationale, `blocked_workspace` policy decision, generatedFrom payload populated.
- [x] Re-running cadence with unchanged inputs leaves totals at `active=1` (signature unique index suppresses duplicates).
- [x] Dismiss flips status to `dismissed` with `dismissReason` + `dismissedBy` recorded.
- [x] Re-running cadence after dismiss leaves `active=0, dismissed=1` (dismissed signature is suppressed).
- [ ] Production smoke: enable Operating Loop on CT165 (already disabled via env) and confirm suggestions appear after cadence ticks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)