### PR TITLE
feat: promote operating loop suggestion to queued agentrun v4

### DIFF
--- a/packages/daemon/src/db/client.ts
+++ b/packages/daemon/src/db/client.ts
@@ -630,6 +630,10 @@ CREATE TABLE IF NOT EXISTS cb_agent_run_suggestions (
   rationale TEXT NOT NULL,
   policy_decision TEXT NOT NULL,
   generated_from TEXT NOT NULL,
+  promoted_agent_run_id TEXT,
+  promoted_by TEXT,
+  promoted_at INTEGER,
+  promotion_rationale TEXT,
   dismiss_reason TEXT,
   dismissed_by TEXT,
   dismissed_at INTEGER,
@@ -1040,6 +1044,31 @@ export function getDb() {
     }
     if (!agentRunColNames.has("last_log_line_count")) {
       sqlite.exec("ALTER TABLE cb_agent_runs ADD COLUMN last_log_line_count INTEGER");
+    }
+
+    const suggestionCols = sqlite
+      .prepare("PRAGMA table_info(cb_agent_run_suggestions)")
+      .all() as Array<{ name: string }>;
+    const suggestionColNames = new Set(suggestionCols.map((c) => c.name));
+    if (!suggestionColNames.has("promoted_agent_run_id")) {
+      sqlite.exec(
+        "ALTER TABLE cb_agent_run_suggestions ADD COLUMN promoted_agent_run_id TEXT"
+      );
+    }
+    if (!suggestionColNames.has("promoted_by")) {
+      sqlite.exec(
+        "ALTER TABLE cb_agent_run_suggestions ADD COLUMN promoted_by TEXT"
+      );
+    }
+    if (!suggestionColNames.has("promoted_at")) {
+      sqlite.exec(
+        "ALTER TABLE cb_agent_run_suggestions ADD COLUMN promoted_at INTEGER"
+      );
+    }
+    if (!suggestionColNames.has("promotion_rationale")) {
+      sqlite.exec(
+        "ALTER TABLE cb_agent_run_suggestions ADD COLUMN promotion_rationale TEXT"
+      );
     }
 
     const guidanceCols = sqlite.prepare("PRAGMA table_info(cb_guidance_items)").all() as Array<{

--- a/packages/daemon/src/db/schema.ts
+++ b/packages/daemon/src/db/schema.ts
@@ -728,6 +728,10 @@ export const cbAgentRunSuggestions = sqliteTable("cb_agent_run_suggestions", {
       operatingLoopScheduledAt: number | null;
     }>()
     .notNull(),
+  promotedAgentRunId: text("promoted_agent_run_id"),
+  promotedBy: text("promoted_by"),
+  promotedAt: integer("promoted_at", { mode: "number" }),
+  promotionRationale: text("promotion_rationale"),
   dismissReason: text("dismiss_reason"),
   dismissedBy: text("dismissed_by"),
   dismissedAt: integer("dismissed_at", { mode: "number" }),

--- a/packages/daemon/src/routes/company-brain.ts
+++ b/packages/daemon/src/routes/company-brain.ts
@@ -100,6 +100,8 @@ import type {
   DismissAgentRunSuggestionResponse,
   EvaluateAutoDispatchEligibilityRequest,
   ListAgentRunSuggestionsResponse,
+  PromoteAgentRunSuggestionRequest,
+  PromoteAgentRunSuggestionResponse,
   CreateAgentRunRequest,
   UpdateAgentRunRequest,
   DecomposeOperatingGoalRequest,
@@ -18144,6 +18146,10 @@ function generateAgentRunSuggestionsForOperatingLoop(args: {
     rationale,
     policyDecision: policy.decision as unknown as Record<string, unknown>,
     generatedFrom,
+    promotedAgentRunId: null,
+    promotedBy: null,
+    promotedAt: null,
+    promotionRationale: null,
     dismissReason: null,
     dismissedBy: null,
     dismissedAt: null,
@@ -18240,6 +18246,211 @@ app.post("/agent-run-suggestions/:id/dismiss", async (c) => {
     suggestion: refreshed,
   };
   return c.json({ data: response });
+});
+
+app.post("/agent-run-suggestions/:id/promote", async (c) => {
+  const id = c.req.param("id");
+  const db = getDb();
+  const existing = db
+    .select()
+    .from(cbAgentRunSuggestions)
+    .where(eq(cbAgentRunSuggestions.id, id))
+    .get() as AgentRunSuggestion | undefined;
+  if (!existing) {
+    return c.json(
+      { error: "not_found", message: `agent run suggestion ${id} not found` },
+      404
+    );
+  }
+  if (existing.status === "dismissed") {
+    return c.json(
+      {
+        error: "validation",
+        message: `suggestion ${id} is dismissed; cannot promote`,
+      },
+      400
+    );
+  }
+  if (existing.status === "superseded") {
+    return c.json(
+      {
+        error: "validation",
+        message: `suggestion ${id} is superseded; only the active suggestion for this WorkItem can be promoted`,
+      },
+      400
+    );
+  }
+  const body = (await c.req
+    .json<PromoteAgentRunSuggestionRequest>()
+    .catch(() => ({}))) as PromoteAgentRunSuggestionRequest;
+  const actor = body.actor?.trim();
+  const rationale = body.rationale?.trim();
+  if (!actor) {
+    return c.json({ error: "validation", message: "actor is required" }, 400);
+  }
+  if (!rationale) {
+    return c.json(
+      { error: "validation", message: "rationale is required" },
+      400
+    );
+  }
+
+  // Idempotent path: already promoted → return existing AgentRun if it still exists.
+  if (existing.promotedAgentRunId) {
+    const priorRun = db
+      .select()
+      .from(cbAgentRuns)
+      .where(eq(cbAgentRuns.id, existing.promotedAgentRunId))
+      .get() as AgentRun | undefined;
+    if (priorRun) {
+      const response: PromoteAgentRunSuggestionResponse = {
+        generatedAt: now(),
+        suggestion: existing,
+        agentRun: priorRun,
+        alreadyPromoted: true,
+      };
+      return c.json({ data: response });
+    }
+    // promoted_agent_run_id pointed to a deleted run; reset and recreate.
+  }
+
+  // Auto-dispatch actor must pass eligibility before promotion creates an AgentRun.
+  const isAutoDispatchActor = actor.startsWith("operating-loop:auto-dispatch");
+  if (isAutoDispatchActor) {
+    const targetWorkItem =
+      (db
+        .select()
+        .from(cbWorkItems)
+        .where(eq(cbWorkItems.id, existing.workItemId))
+        .get() as WorkItem | undefined) ?? null;
+    const eligibility = evaluateAutoDispatchEligibility({
+      workItem: targetWorkItem,
+      suggestion: existing,
+      actorOverride: actor,
+      rationaleOverride: rationale,
+    });
+    if (!eligibility.eligible) {
+      return c.json(
+        {
+          error: "auto_dispatch_blocked",
+          message: `auto-dispatch actor ${actor} cannot promote: decision=${eligibility.decision}, blockReasons=[${eligibility.blockReasons.join(",")}]`,
+          data: { eligibility },
+        },
+        403
+      );
+    }
+  }
+
+  // Resolve repo + workflow context for the new AgentRun.
+  const workflow = loadWorkflowFromRepoRoot();
+  const repo = workflow.config.tracker.repo ?? null;
+  const targetWorkItem =
+    (db
+      .select()
+      .from(cbWorkItems)
+      .where(eq(cbWorkItems.id, existing.workItemId))
+      .get() as WorkItem | undefined) ?? null;
+  if (!targetWorkItem) {
+    return c.json(
+      {
+        error: "validation",
+        message: `WorkItem ${existing.workItemId} not found; cannot promote`,
+      },
+      400
+    );
+  }
+
+  const timestamp = now();
+  const newRunId = nanoid(12);
+  const auditEntry = {
+    at: timestamp,
+    actor,
+    event: "agent_run_promoted_from_suggestion",
+    note: rationale,
+    metadata: {
+      suggestionId: existing.id,
+      signature: existing.signature,
+      autoDispatchActor: isAutoDispatchActor,
+    },
+  };
+  const newRun: AgentRun = {
+    id: newRunId,
+    workItemId: existing.workItemId,
+    workflowRunId: null,
+    agentContextId: null,
+    sourceId: targetWorkItem.sourceId ?? null,
+    repo,
+    branch: null,
+    workspaceRef: null,
+    runnerType: existing.runnerType,
+    status: "queued",
+    claimState: "unclaimed",
+    attempt: 0,
+    startedAt: null,
+    finishedAt: null,
+    errorSummary: null,
+    prUrl: null,
+    externalRunRef: null,
+    tokensInput: null,
+    tokensOutput: null,
+    tokensTotal: null,
+    costUsd: null,
+    agentSessionId: null,
+    agentThreadId: null,
+    area: targetWorkItem.area,
+    riskClass: targetWorkItem.riskClass,
+    actionPolicy: "observe_only",
+    visibility: targetWorkItem.visibility ?? "internal",
+    pid: null,
+    executionRef: null,
+    lastLogAt: null,
+    lastLogLineCount: null,
+    metadata: {
+      promotedFromSuggestionId: existing.id,
+      suggestionSignature: existing.signature,
+      promotedBy: actor,
+      promotionRationale: rationale,
+      sourceIssueRef: existing.generatedFrom.sourceIssueRef,
+      operatingLoopScheduleId: existing.generatedFrom.operatingLoopScheduleId,
+      operatingLoopScheduledAt: existing.generatedFrom.operatingLoopScheduledAt,
+    },
+    auditTrail: [auditEntry],
+    provenance: {
+      sourceId: targetWorkItem.sourceId ?? "",
+      rawRef: `aios://agent-run-suggestion/${existing.id}`,
+      createdFrom: "company_brain:agent_run_suggestion_promotion",
+      confidence: 1,
+      extractedAt: timestamp,
+      humanReviewStatus: "pending",
+      visibility: targetWorkItem.visibility ?? "internal",
+      notes: `Promoted from suggestion ${existing.id} (signature ${existing.signature.slice(0, 12)}...) by ${actor}`,
+    },
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+  db.insert(cbAgentRuns).values(newRun as never).run();
+  db.update(cbAgentRunSuggestions)
+    .set({
+      promotedAgentRunId: newRunId,
+      promotedBy: actor,
+      promotedAt: timestamp,
+      promotionRationale: rationale,
+      updatedAt: timestamp,
+    } as never)
+    .where(eq(cbAgentRunSuggestions.id, id))
+    .run();
+  const refreshed = db
+    .select()
+    .from(cbAgentRunSuggestions)
+    .where(eq(cbAgentRunSuggestions.id, id))
+    .get() as AgentRunSuggestion;
+  const response: PromoteAgentRunSuggestionResponse = {
+    generatedAt: timestamp,
+    suggestion: refreshed,
+    agentRun: newRun,
+    alreadyPromoted: false,
+  };
+  return c.json({ data: response }, 201);
 });
 
 app.get("/gate-closure-ritual", (c) => {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1647,6 +1647,30 @@ server.registerTool(
 );
 
 server.registerTool(
+  "promote_company_brain_agent_run_suggestion",
+  {
+    title: "Promote Company Brain AgentRun suggestion",
+    description:
+      "Idempotently promote an active AgentRun suggestion into a queued AgentRun. Re-promotion returns the existing AgentRun. Auto-dispatch actors require eligibility to pass. No subprocess is launched.",
+    inputSchema: {
+      suggestionId: z.string().min(1),
+      actor: z.string().min(1),
+      rationale: z.string().min(1),
+    },
+  },
+  async ({ suggestionId, actor, rationale }) => {
+    const result = await daemonFetch<{ data: unknown }>(
+      `/api/company-brain/agent-run-suggestions/${suggestionId}/promote`,
+      {
+        method: "POST",
+        body: JSON.stringify({ actor, rationale }),
+      }
+    );
+    return formatJsonResult(result.data);
+  }
+);
+
+server.registerTool(
   "dismiss_company_brain_agent_run_suggestion",
   {
     title: "Dismiss Company Brain AgentRun suggestion",

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1653,11 +1653,27 @@ export interface AgentRunSuggestion {
   rationale: string;
   policyDecision: Record<string, unknown>;
   generatedFrom: AgentRunSuggestionGeneratedFrom;
+  promotedAgentRunId: string | null;
+  promotedBy: string | null;
+  promotedAt: number | null;
+  promotionRationale: string | null;
   dismissReason: string | null;
   dismissedBy: string | null;
   dismissedAt: number | null;
   createdAt: number;
   updatedAt: number;
+}
+
+export interface PromoteAgentRunSuggestionRequest {
+  actor: string;
+  rationale: string;
+}
+
+export interface PromoteAgentRunSuggestionResponse {
+  generatedAt: number;
+  suggestion: AgentRunSuggestion;
+  agentRun: AgentRun;
+  alreadyPromoted: boolean;
 }
 
 export interface ListAgentRunSuggestionsResponse {

--- a/packages/web/src/app/company-brain/agent-runs/page.tsx
+++ b/packages/web/src/app/company-brain/agent-runs/page.tsx
@@ -25,6 +25,7 @@ import {
   useDismissCompanyBrainAgentRunSuggestion,
   useEvaluateCompanyBrainAgentRunPolicy,
   useExecuteCompanyBrainAgentRun,
+  usePromoteCompanyBrainAgentRunSuggestion,
 } from "@/hooks/use-api";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -333,14 +334,21 @@ interface AgentRunSuggestionRow {
     operatingLoopScheduleId: string | null;
     operatingLoopScheduledAt: number | null;
   };
+  promotedAgentRunId: string | null;
+  promotedBy: string | null;
+  promotedAt: number | null;
   createdAt: number;
 }
 
 function SuggestionRow({ suggestion }: { suggestion: AgentRunSuggestionRow }) {
   const dismissMutation = useDismissCompanyBrainAgentRunSuggestion();
+  const promoteMutation = usePromoteCompanyBrainAgentRunSuggestion();
   const [actor, setActor] = useState("");
   const [rationale, setRationale] = useState("");
   const [open, setOpen] = useState(false);
+  const [promoteOpen, setPromoteOpen] = useState(false);
+  const [promoteActor, setPromoteActor] = useState("");
+  const [promoteRationale, setPromoteRationale] = useState("");
   return (
     <li className="border-t border-border first:border-t-0">
       <div className="flex flex-col gap-2 p-3 sm:flex-row sm:items-start sm:justify-between">
@@ -368,12 +376,94 @@ function SuggestionRow({ suggestion }: { suggestion: AgentRunSuggestionRow }) {
           </p>
           <p className="mt-1 text-[11px] text-muted-foreground">
             Created {formatTimeAgo(suggestion.createdAt)} · Observe-only — no subprocess will start.
+            {suggestion.promotedAgentRunId ? (
+              <>
+                {" · "}
+                <span className="text-emerald-500">
+                  Promoted → AgentRun <code className="text-[11px]">{suggestion.promotedAgentRunId}</code>
+                  {suggestion.promotedBy ? ` by ${suggestion.promotedBy}` : ""}
+                </span>
+              </>
+            ) : null}
           </p>
         </div>
         <div className="flex flex-col gap-1 sm:w-64">
-          <Button size="sm" variant="ghost" onClick={() => setOpen(!open)} className="self-end">
-            {open ? "Cancel" : "Dismiss"}
-          </Button>
+          <div className="flex gap-1 self-end">
+            {!suggestion.promotedAgentRunId ? (
+              <Button
+                size="sm"
+                variant="default"
+                onClick={() => {
+                  setPromoteOpen(!promoteOpen);
+                  setOpen(false);
+                }}
+              >
+                {promoteOpen ? "Cancel" : "Promote"}
+              </Button>
+            ) : null}
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => {
+                setOpen(!open);
+                setPromoteOpen(false);
+              }}
+            >
+              {open ? "Cancel" : "Dismiss"}
+            </Button>
+          </div>
+          {promoteOpen ? (
+            <div className="flex flex-col gap-1 rounded border border-border p-2">
+              <input
+                type="text"
+                value={promoteActor}
+                onChange={(e) => setPromoteActor(e.target.value)}
+                placeholder="actor"
+                className="w-full rounded border border-input bg-background px-2 py-1 text-xs"
+              />
+              <input
+                type="text"
+                value={promoteRationale}
+                onChange={(e) => setPromoteRationale(e.target.value)}
+                placeholder="rationale for promotion"
+                className="w-full rounded border border-input bg-background px-2 py-1 text-xs"
+              />
+              <Button
+                size="sm"
+                variant="default"
+                onClick={() =>
+                  promoteMutation.mutate(
+                    {
+                      suggestionId: suggestion.id,
+                      actor: promoteActor,
+                      rationale: promoteRationale,
+                    },
+                    {
+                      onSuccess: () => {
+                        setPromoteOpen(false);
+                        setPromoteActor("");
+                        setPromoteRationale("");
+                      },
+                    }
+                  )
+                }
+                disabled={
+                  !promoteActor.trim() ||
+                  !promoteRationale.trim() ||
+                  promoteMutation.isPending
+                }
+              >
+                {promoteMutation.isPending ? <Loader2 className="size-3 animate-spin" /> : <PlayCircle className="size-3" />}
+                Confirm promote
+              </Button>
+              {promoteMutation.isError ? (
+                <p className="text-[10px] text-destructive">{promoteMutation.error.message}</p>
+              ) : null}
+              <p className="text-[10px] text-muted-foreground">
+                Creates a queued AgentRun. No subprocess will run until you Execute manually.
+              </p>
+            </div>
+          ) : null}
           {open ? (
             <div className="flex flex-col gap-1 rounded border border-border p-2">
               <input

--- a/packages/web/src/hooks/use-api.ts
+++ b/packages/web/src/hooks/use-api.ts
@@ -561,6 +561,26 @@ export function useCompanyBrainAgentRunSuggestions(status: string = "active") {
   });
 }
 
+export function usePromoteCompanyBrainAgentRunSuggestion() {
+  const qc = useQueryClient();
+  return useMutation<ApiResponse<unknown>, Error, {
+    suggestionId: string;
+    actor: string;
+    rationale: string;
+  }>({
+    mutationFn: ({ suggestionId, ...rest }) =>
+      api(`/api/company-brain/agent-run-suggestions/${suggestionId}/promote`, {
+        method: "POST",
+        body: JSON.stringify(rest),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["company-brain", "agent-run-suggestions"] });
+      qc.invalidateQueries({ queryKey: ["company-brain", "agent-runs"] });
+      qc.invalidateQueries({ queryKey: ["company-brain", "operating-snapshot"] });
+    },
+  });
+}
+
 export function useDismissCompanyBrainAgentRunSuggestion() {
   const qc = useQueryClient();
   return useMutation<ApiResponse<unknown>, Error, {


### PR DESCRIPTION
## Summary

Closes #85

AIOS-RUN-20: idempotent promotion path from `AgentRunSuggestion` to a queued `AgentRun`. No subprocess is launched by promotion alone.

### Schema

`cb_agent_run_suggestions` gains four columns (idempotent ALTER TABLE + updated CREATE TABLE):

- `promoted_agent_run_id`
- `promoted_by`
- `promoted_at`
- `promotion_rationale`

### Endpoint

`POST /api/company-brain/agent-run-suggestions/:id/promote` with `{actor, rationale}`:

| Path | Behavior |
|---|---|
| Suggestion not found | 404 |
| Suggestion `dismissed` | 400 |
| Suggestion `superseded` | 400 |
| Empty `actor` or `rationale` | 400 |
| `promotedAgentRunId` set + run still exists | 200 with `alreadyPromoted=true` |
| Actor starts with `operating-loop:auto-dispatch` | runs AIOS-RUN-19 `evaluateAutoDispatchEligibility`; 403 with eligibility payload if not eligible |
| Otherwise | 201 with new queued `AgentRun` and `alreadyPromoted=false` |

The new AgentRun gets:

- `status=queued`, `claimState=unclaimed`, `attempt=0`
- `area`, `riskClass`, `visibility` copied from the WorkItem
- `repo` from `WORKFLOW.md` tracker.repo
- `runnerType` from the suggestion
- `metadata`: `promotedFromSuggestionId`, `suggestionSignature`, `promotedBy`, `promotionRationale`, `sourceIssueRef`, operating loop schedule pointer
- `provenance.rawRef` = `aios://agent-run-suggestion/<id>`
- Audit trail starts with `agent_run_promoted_from_suggestion` entry

The suggestion is updated with `promotedAgentRunId/by/at/rationale`.

### Surfacing

- `AgentRunSuggestion` type gains 4 new fields.
- `/company-brain/agent-runs` UI: each Suggestion row gets a **Promote** button (alongside Dismiss). Promotion form requires actor + rationale. On success the row shows `Promoted → AgentRun <id> by <actor>`. The Promote button hides once the suggestion is promoted.
- MCP tool: `promote_company_brain_agent_run_suggestion`.

### Test plan

- [x] `npx turbo build` clean.
- [x] Promote (manual actor): 201, `alreadyPromoted=false`, AgentRun created with `status=queued` and `metadata.promotedFromSuggestionId`.
- [x] Re-promote: 200 with `alreadyPromoted=true`, returns same AgentRun id.
- [x] Promote unknown id: 404 `not_found`.
- [x] Promote without actor: 400 `actor is required`.
- [ ] Production smoke after deploy: confirm endpoint exists and 404s on a non-existent suggestion id.

### Constraints honored

- No subprocess launch from promotion.
- No external writeback.
- No new secrets, no paid services.
- Auto-dispatch actor still gated by AIOS-RUN-19 eligibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)