### PR TITLE
feat: auto-dispatch config clarity and policy hints v5

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -71,3 +71,53 @@ You are the AIOS Execution Loop agent for issue {{ issue.identifier }}: {{ issue
 - Open PR with `Closes {{ issue.external_id }}`.
 - Update `docs/backlog.md` with a status line for the cut.
 - Submit a session_result via `mcp__aios__submit_company_brain_session_result` referencing the WorkItem and the PR.
+
+## Auto-dispatch env vars
+
+Auto-dispatch is **default-off** in production. Opt-in requires the following env vars (all checked via `evaluateAutoDispatchEligibility`). Each gate response now carries `envRefs`, `expectedFormat`, `exampleValue` and `docsLink` to make config errors fixable without reading source.
+
+| Env var | Format | Example | Notes |
+|---|---|---|---|
+| `AIOS_AGENT_AUTODISPATCH_ENABLED` | boolean string | `true` | Master switch. Unset or anything other than `"true"` keeps auto-dispatch blocked. |
+| `AIOS_AGENT_AUTODISPATCH_REPO_ALLOWLIST` | CSV of `owner/name` | `antonio-mello-ai/crewdock` | GitHub repo identifiers, **not** filesystem paths. Must include `WORKFLOW.md` `tracker.repo`. |
+| `AIOS_AGENT_AUTODISPATCH_WORKFLOW_ALLOWLIST` | CSV of blueprint ids | `development-blueprint-v0` | Must match `cb_workflow_blueprints.id` exactly. v5 (#95) lets you create blueprints with stable client-supplied ids. |
+| `AIOS_AGENT_AUTODISPATCH_AREA_ALLOWLIST` | CSV of `CompanyBrainArea` | `development,platform` | Allowed values: `strategy`, `development`, `operations`, `product`, `marketing`, `sales`, `finance`, `people`, `customer`, `platform`. |
+| `AIOS_AGENT_AUTODISPATCH_REQUIRE_RISK_A` | boolean string | `true` | When `true` (default), only Risk A WorkItems are eligible. Set `false` to allow Risk B with documented rationale. |
+| `AIOS_AGENT_AUTODISPATCH_MAX_CONCURRENCY` | int | `1` | Max active runs at any time across the daemon. Defaults to 1; the loop also enforces single-run-per-tick. |
+| `AIOS_AGENT_AUTODISPATCH_TOKEN_BUDGET` | int | `100000` | Tokens spent in the cooldown window. Auto-dispatch refuses when window budget is exhausted. |
+| `AIOS_AGENT_AUTODISPATCH_COOLDOWN_MS` | int (ms) | `900000` | Minimum gap between auto-dispatches; also defines the budget window. |
+| `AIOS_AGENT_AUTODISPATCH_MAX_RUNTIME_MS` | int (ms) | `600000` | Per-run timeout. Reconciler marks runs `failed` when exceeded. |
+| `AIOS_AGENT_AUTODISPATCH_DEFAULT_ACTOR` | string | `operating-loop:auto-dispatch` | Audit actor for promote + execute-async calls. |
+| `AIOS_AGENT_AUTODISPATCH_DEFAULT_RATIONALE` | string | `Auto-dispatched by Operating Loop after eligibility evaluation` | Default rationale recorded on AgentRun. |
+
+## Manual runner env vars
+
+Auto-dispatch chains `evaluateRunnerPolicy(intent=real_execution)`, so the manual runner env vars must also be set:
+
+| Env var | Format | Example | Notes |
+|---|---|---|---|
+| `AIOS_AGENT_RUNNER_ENABLED` | boolean string | `true` | Master switch for any real subprocess (manual or auto). |
+| `AIOS_AGENT_RUNNER_REPO_ALLOWLIST` | CSV of `owner/name` | `antonio-mello-ai/crewdock` | Mirrors auto-dispatch repo allowlist. |
+| `AIOS_AGENT_RUNNER_COMMAND_ALLOWLIST` | CSV of binaries | `claude,echo,true` | Must include `WORKFLOW.md` `agent.command` (e.g., `claude`). Defaults to `claude,codex,echo,true`. |
+| `AIOS_AGENT_WORKSPACE_ENABLED` | boolean string | `true` | Enables workspace prepare/cleanup endpoints. |
+| `AIOS_AGENT_WORKSPACE_ALLOWLIST` | **CSV of `owner/name`** | `antonio-mello-ai/crewdock` | **Repo identifiers, NOT filesystem paths.** The workspace path itself is derived from `WORKFLOW.md` `workspace.root` (default `~/.aios/agent-workspaces`); this allowlist controls which repos can use that root. |
+
+The workspace path is computed as `${workspace.root}/${owner_repo}/${workItemKey}-${runId.slice(0,8)}`. The cleanup gate (#78) refuses to remove anything outside `workspace.root`.
+
+## Failed gate response shape
+
+```ts
+interface AutoDispatchGate {
+  key: string;
+  title: string;
+  status: "passed" | "failed" | "warn";
+  detail: string;
+  remediation?: string;
+  envRefs?: string[];        // env vars that need to be fixed
+  expectedFormat?: string;   // human-readable contract
+  exampleValue?: string;     // ready-to-paste value
+  docsLink?: string;         // pointer to deeper docs
+}
+```
+
+The console renders `envRefs` and `exampleValue` inline so an operator can fix config without re-reading source.

--- a/packages/daemon/src/routes/company-brain.ts
+++ b/packages/daemon/src/routes/company-brain.ts
@@ -12822,6 +12822,10 @@ function evaluateAutoDispatchEligibility(args: {
         "AIOS_AGENT_AUTODISPATCH_ENABLED is not set to true; auto-dispatch is default-off.",
       remediation:
         "Set AIOS_AGENT_AUTODISPATCH_ENABLED=true on a controlled environment after the rest of the gates pass.",
+      envRefs: ["AIOS_AGENT_AUTODISPATCH_ENABLED"],
+      expectedFormat: "boolean string ('true' or unset)",
+      exampleValue: "true",
+      docsLink: "WORKFLOW.md#auto-dispatch-env-vars",
     });
     blockReasons.push("autodispatch_disabled");
     setBlock("blocked_default_off");
@@ -12847,6 +12851,10 @@ function evaluateAutoDispatchEligibility(args: {
         "AIOS_AGENT_AUTODISPATCH_REPO_ALLOWLIST is empty; auto-dispatch refuses to act on any repo.",
       remediation:
         "Set AIOS_AGENT_AUTODISPATCH_REPO_ALLOWLIST to a CSV of allowlisted repos (owner/name).",
+      envRefs: ["AIOS_AGENT_AUTODISPATCH_REPO_ALLOWLIST"],
+      expectedFormat: "CSV of GitHub repo identifiers in `owner/name` form (NOT filesystem paths)",
+      exampleValue: "antonio-mello-ai/crewdock",
+      docsLink: "WORKFLOW.md#auto-dispatch-env-vars",
     });
     blockReasons.push("autodispatch_repo_allowlist_empty");
     setBlock("blocked_repo");
@@ -12858,6 +12866,7 @@ function evaluateAutoDispatchEligibility(args: {
       detail: "WORKFLOW.md tracker.repo is missing.",
       remediation:
         "Set tracker.repo in WORKFLOW.md before enabling auto-dispatch.",
+      docsLink: "WORKFLOW.md#tracker",
     });
     blockReasons.push("autodispatch_repo_missing");
     setBlock("blocked_repo");
@@ -12868,6 +12877,10 @@ function evaluateAutoDispatchEligibility(args: {
       status: "failed",
       detail: `repo=${repo} is not in AIOS_AGENT_AUTODISPATCH_REPO_ALLOWLIST.`,
       remediation: `Add ${repo} to AIOS_AGENT_AUTODISPATCH_REPO_ALLOWLIST or fix tracker.repo.`,
+      envRefs: ["AIOS_AGENT_AUTODISPATCH_REPO_ALLOWLIST"],
+      expectedFormat: "CSV of GitHub repo identifiers in `owner/name` form",
+      exampleValue: repo,
+      docsLink: "WORKFLOW.md#auto-dispatch-env-vars",
     });
     blockReasons.push("autodispatch_repo_not_allowed");
     setBlock("blocked_repo");
@@ -12890,7 +12903,11 @@ function evaluateAutoDispatchEligibility(args: {
       detail:
         "AIOS_AGENT_AUTODISPATCH_WORKFLOW_ALLOWLIST is empty; auto-dispatch refuses to act on any workflow blueprint.",
       remediation:
-        "Set AIOS_AGENT_AUTODISPATCH_WORKFLOW_ALLOWLIST to a CSV of workflow blueprint refs registered in cbWorkflowBlueprints.",
+        "Set AIOS_AGENT_AUTODISPATCH_WORKFLOW_ALLOWLIST to a CSV of workflow blueprint ids registered in cb_workflow_blueprints.",
+      envRefs: ["AIOS_AGENT_AUTODISPATCH_WORKFLOW_ALLOWLIST"],
+      expectedFormat: "CSV of workflow blueprint ids (matches cb_workflow_blueprints.id, NOT a free-form ref string)",
+      exampleValue: "development-blueprint-v0",
+      docsLink: "WORKFLOW.md#auto-dispatch-env-vars",
     });
     blockReasons.push("autodispatch_workflow_allowlist_empty");
     setBlock("blocked_workflow");
@@ -12908,9 +12925,13 @@ function evaluateAutoDispatchEligibility(args: {
         key: "workflow_allowed",
         title: "Workflow allowlisted for auto-dispatch",
         status: "failed",
-        detail: `Allowlist=[${config.workflowAllowlist.join(",")}] does not match any registered workflow blueprint ref (registered=${blueprintRefs.length}).`,
+        detail: `Allowlist=[${config.workflowAllowlist.join(",")}] does not match any registered workflow blueprint id (registered=${blueprintRefs.length}; first 3=[${blueprintRefs.slice(0, 3).join(",")}]).`,
         remediation:
-          "Register a workflow blueprint with one of the allowlisted refs, or update the allowlist to a registered ref.",
+          "Register a workflow blueprint with one of the allowlisted ids (POST /workflow-blueprints + #95 stable id contract), or update the allowlist to a registered id.",
+        envRefs: ["AIOS_AGENT_AUTODISPATCH_WORKFLOW_ALLOWLIST"],
+        expectedFormat: "CSV of workflow blueprint ids (must match cb_workflow_blueprints.id exactly)",
+        exampleValue: blueprintRefs[0] ?? "development-blueprint-v0",
+        docsLink: "WORKFLOW.md#auto-dispatch-env-vars",
       });
       blockReasons.push("autodispatch_workflow_not_allowed");
       setBlock("blocked_workflow");
@@ -12943,6 +12964,11 @@ function evaluateAutoDispatchEligibility(args: {
         "AIOS_AGENT_AUTODISPATCH_AREA_ALLOWLIST is empty; auto-dispatch refuses to act on any area.",
       remediation:
         "Set AIOS_AGENT_AUTODISPATCH_AREA_ALLOWLIST to a CSV of allowlisted areas.",
+      envRefs: ["AIOS_AGENT_AUTODISPATCH_AREA_ALLOWLIST"],
+      expectedFormat:
+        "CSV of CompanyBrainArea values: strategy, development, operations, product, marketing, sales, finance, people, customer, platform",
+      exampleValue: "development,platform",
+      docsLink: "WORKFLOW.md#auto-dispatch-env-vars",
     });
     blockReasons.push("autodispatch_area_allowlist_empty");
     setBlock("blocked_area");
@@ -12953,6 +12979,10 @@ function evaluateAutoDispatchEligibility(args: {
       status: "failed",
       detail: `WorkItem.area=${args.workItem.area} ∉ allowlist=[${config.areaAllowlist.join(",")}]`,
       remediation: `Add ${args.workItem.area} to AIOS_AGENT_AUTODISPATCH_AREA_ALLOWLIST or pick a different WorkItem.`,
+      envRefs: ["AIOS_AGENT_AUTODISPATCH_AREA_ALLOWLIST"],
+      expectedFormat: "CSV of CompanyBrainArea values",
+      exampleValue: [...config.areaAllowlist, args.workItem.area].join(","),
+      docsLink: "WORKFLOW.md#auto-dispatch-env-vars",
     });
     blockReasons.push("autodispatch_area_not_allowed");
     setBlock("blocked_area");
@@ -12983,6 +13013,10 @@ function evaluateAutoDispatchEligibility(args: {
       detail: `requireRiskA=true and WorkItem.riskClass=${args.workItem.riskClass} (need A).`,
       remediation:
         "Reduce risk class to A with documented rationale, or disable requireRiskA after independent review.",
+      envRefs: ["AIOS_AGENT_AUTODISPATCH_REQUIRE_RISK_A"],
+      expectedFormat: "boolean string (default 'true' enforces Risk A only; set 'false' to allow Risk B)",
+      exampleValue: "false",
+      docsLink: "WORKFLOW.md#auto-dispatch-env-vars",
     });
     blockReasons.push("autodispatch_risk_not_a");
     setBlock("blocked_risk");
@@ -12996,6 +13030,7 @@ function evaluateAutoDispatchEligibility(args: {
       status: "failed",
       detail: `WorkItem.riskClass=${args.workItem.riskClass} blocked by Writeback Policy Matrix.`,
       remediation: "Refactor to Risk A or B with HITL approval and audit.",
+      docsLink: "docs/decisions/writeback-policy-matrix.md",
     });
     blockReasons.push("autodispatch_risk_blocked");
     setBlock("blocked_risk");
@@ -13136,13 +13171,53 @@ function evaluateAutoDispatchEligibility(args: {
         });
         satisfiedGates.push("manual_runner_policy_passed");
       } else {
+        // Pull blocked manual gates so operators can see the exact env var
+        // they need to fix without re-evaluating /policy/evaluate.
+        const failedManualGates = policy.gates
+          .filter((g) => g.status === "failed")
+          .map((g) => g.key);
+        const manualEnvHint = (() => {
+          const hints: string[] = [];
+          if (policy.blockReasons.includes("workspace_not_allowlisted")) {
+            hints.push(
+              "AIOS_AGENT_WORKSPACE_ALLOWLIST=<owner/name> (CSV of GitHub repo identifiers, NOT filesystem paths)"
+            );
+          }
+          if (policy.blockReasons.includes("command_not_allowlisted")) {
+            hints.push(
+              "AIOS_AGENT_RUNNER_COMMAND_ALLOWLIST=claude,echo,true (CSV of allowed binaries; must include WORKFLOW.md agent.command)"
+            );
+          }
+          if (policy.blockReasons.includes("runner_disabled")) {
+            hints.push("AIOS_AGENT_RUNNER_ENABLED=true (master switch for manual runner)");
+          }
+          if (policy.blockReasons.includes("repo_not_allowlisted")) {
+            hints.push(
+              "AIOS_AGENT_RUNNER_REPO_ALLOWLIST=<owner/name> (CSV mirrors AUTODISPATCH_REPO_ALLOWLIST)"
+            );
+          }
+          return hints;
+        })();
         gates.push({
           key: "manual_runner_policy_passed",
           title: "Manual runner policy passes",
           status: "failed",
-          detail: `evaluateRunnerPolicy=${policy.decision}; satisfiedGates=${policy.gates.filter((g) => g.status === "passed").length}; blockReasons=[${policy.blockReasons.join(",")}]`,
+          detail: `evaluateRunnerPolicy=${policy.decision}; satisfiedGates=${policy.gates.filter((g) => g.status === "passed").length}; manualBlockReasons=[${policy.blockReasons.join(",")}]; failedGates=[${failedManualGates.join(",")}]`,
           remediation:
-            "Fix manual runner policy gates first; auto-dispatch chains the same policy.",
+            manualEnvHint.length > 0
+              ? `Fix manual runner policy first: ${manualEnvHint.join("; ")}`
+              : "Fix manual runner policy gates first; auto-dispatch chains the same policy. Run POST /agent-runs/:id/policy/evaluate for full gate detail.",
+          envRefs: [
+            "AIOS_AGENT_RUNNER_ENABLED",
+            "AIOS_AGENT_RUNNER_REPO_ALLOWLIST",
+            "AIOS_AGENT_RUNNER_COMMAND_ALLOWLIST",
+            "AIOS_AGENT_WORKSPACE_ALLOWLIST",
+          ],
+          expectedFormat:
+            "All four manual runner env vars must be set; AIOS_AGENT_WORKSPACE_ALLOWLIST takes repo identifiers (owner/name), NOT filesystem paths",
+          exampleValue:
+            "AIOS_AGENT_WORKSPACE_ALLOWLIST=" + (repo ?? "antonio-mello-ai/crewdock"),
+          docsLink: "WORKFLOW.md#manual-runner-env-vars",
         });
         blockReasons.push("autodispatch_runner_policy_blocked");
         setBlock("blocked_runner_policy");

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1577,6 +1577,10 @@ export interface AutoDispatchGate {
   status: AutoDispatchGateStatus;
   detail: string;
   remediation?: string;
+  envRefs?: string[];
+  expectedFormat?: string;
+  exampleValue?: string;
+  docsLink?: string;
 }
 
 export interface AutoDispatchPolicyConfig {

--- a/packages/web/src/app/company-brain/agent-runs/page.tsx
+++ b/packages/web/src/app/company-brain/agent-runs/page.tsx
@@ -516,6 +516,11 @@ interface AutoDispatchGate {
   title: string;
   status: "passed" | "failed" | "warn";
   detail: string;
+  remediation?: string;
+  envRefs?: string[];
+  expectedFormat?: string;
+  exampleValue?: string;
+  docsLink?: string;
 }
 
 interface AutoDispatchPolicySummaryRow {
@@ -687,7 +692,7 @@ export default function CompanyBrainAgentRunsPage() {
                     <span className="text-[11px] text-muted-foreground">global preview (no WorkItem)</span>
                   )}
                 </div>
-                <ul className="mt-2 grid gap-1 text-[11px] sm:grid-cols-2">
+                <ul className="mt-2 grid gap-2 text-[11px] sm:grid-cols-2">
                   {autoDispatch.eligibilityPreview.gates.map((gate) => (
                     <li key={gate.key} className="flex items-start gap-2">
                       <span
@@ -701,9 +706,35 @@ export default function CompanyBrainAgentRunsPage() {
                       >
                         {gate.status === "passed" ? "✓" : gate.status === "warn" ? "⚠" : "✗"}
                       </span>
-                      <span>
-                        <span className="font-medium">{gate.title}</span>: {gate.detail}
-                      </span>
+                      <div className="flex-1">
+                        <p>
+                          <span className="font-medium">{gate.title}</span>: {gate.detail}
+                        </p>
+                        {gate.status === "failed" && gate.envRefs && gate.envRefs.length > 0 ? (
+                          <p className="mt-1 text-muted-foreground">
+                            <span className="font-medium">Env:</span>{" "}
+                            <code className="text-[10px]">{gate.envRefs.join(", ")}</code>
+                            {gate.expectedFormat ? (
+                              <>
+                                {" — "}
+                                {gate.expectedFormat}
+                              </>
+                            ) : null}
+                          </p>
+                        ) : null}
+                        {gate.status === "failed" && gate.exampleValue ? (
+                          <p className="mt-1 text-muted-foreground">
+                            <span className="font-medium">Example:</span>{" "}
+                            <code className="text-[10px]">{gate.exampleValue}</code>
+                          </p>
+                        ) : null}
+                        {gate.status === "failed" && gate.docsLink ? (
+                          <p className="mt-1 text-muted-foreground">
+                            <span className="font-medium">Docs:</span>{" "}
+                            <code className="text-[10px]">{gate.docsLink}</code>
+                          </p>
+                        ) : null}
+                      </div>
                     </li>
                   ))}
                 </ul>


### PR DESCRIPTION
## Summary

Closes #94

AIOS-RUN-24: addresses v4 dogfood friction #1 (env-var semantics confusing) by adding actionable hints on every failed gate and documenting env-var contracts in WORKFLOW.md. No env var is renamed; all changes are backwards-compatible.

### `AutoDispatchGate` shape gains optional hints

```ts
interface AutoDispatchGate {
  key: string;
  title: string;
  status: "passed" | "failed" | "warn";
  detail: string;
  remediation?: string;
  envRefs?: string[];        // env vars to fix
  expectedFormat?: string;   // human-readable contract
  exampleValue?: string;     // ready-to-paste value
  docsLink?: string;         // pointer to deeper docs
}
```

### Hints populated for every failed-gate path

| Gate | envRefs | exampleValue |
|---|---|---|
| `autodispatch_env_enabled` | `AIOS_AGENT_AUTODISPATCH_ENABLED` | `true` |
| `repo_allowed` | `AIOS_AGENT_AUTODISPATCH_REPO_ALLOWLIST` | derived from current `tracker.repo` |
| `workflow_allowed` | `AIOS_AGENT_AUTODISPATCH_WORKFLOW_ALLOWLIST` | first registered `cb_workflow_blueprints.id` |
| `area_allowed` | `AIOS_AGENT_AUTODISPATCH_AREA_ALLOWLIST` | `[...current allowlist, target WorkItem.area]` |
| `risk_class_allowed` | `AIOS_AGENT_AUTODISPATCH_REQUIRE_RISK_A` | `false` |
| `manual_runner_policy_passed` | all 4 manual runner env vars + tailored remediation extracted from chained `evaluateRunnerPolicy.blockReasons` | `AIOS_AGENT_WORKSPACE_ALLOWLIST=<owner/name>` |

The chained-policy gate is the most useful: when manual runner policy blocks (the v4 dogfood friction), the response now includes a remediation string that enumerates the specific env vars to fix, with the "repo identifiers, NOT filesystem paths" gotcha called out inline.

### WORKFLOW.md additions

- **Auto-dispatch env vars** section: 11-row table covering enabled, repo/workflow/area allowlists, requireRiskA, concurrency, budget, cooldown, runtime, default actor/rationale.
- **Manual runner env vars** section: 5-row table covering enabled, repo allowlist, command allowlist, workspace enabled/allowlist with the path-vs-repo-name gotcha highlighted.
- **Failed gate response shape** section: ready-to-copy TypeScript interface.

### UI

`/company-brain/agent-runs` Auto-Dispatch panel renders `envRefs`, `expectedFormat`, `exampleValue`, `docsLink` under each failed gate so the operator never has to leave the console to fix config.

### Test plan

- [x] `npx turbo build` clean.
- [x] **Default-off**: response carries hints for `env_enabled`, `repo_allowed`, `workflow_allowed` (`exampleValue=antonio-mello-ai/crewdock`, `exampleValue=development-blueprint-v0`).
- [x] **Chained runner policy block**: Risk A WI with empty `AIOS_AGENT_WORKSPACE_ALLOWLIST` + `claude` missing from command allowlist → `manual_runner_policy_passed` gate `remediation` lists `AIOS_AGENT_WORKSPACE_ALLOWLIST=<owner/name>` and `AIOS_AGENT_RUNNER_COMMAND_ALLOWLIST=claude,echo,true`.
- [ ] Production smoke after deploy: confirm hints on `/auto-dispatch/policy` default-off response.

### Constraints honored

- No env var renamed.
- No new secret, paid service, external writeback, auto-merge, auto-deploy, or broad auto-dispatch.
- All hint values derived locally; no GITHUB_TOKEN/SLACK_BOT_TOKEN leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)