### PR TITLE
feat: stable workflowblueprint identity for auto-dispatch v5

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -80,7 +80,7 @@ Auto-dispatch is **default-off** in production. Opt-in requires the following en
 |---|---|---|---|
 | `AIOS_AGENT_AUTODISPATCH_ENABLED` | boolean string | `true` | Master switch. Unset or anything other than `"true"` keeps auto-dispatch blocked. |
 | `AIOS_AGENT_AUTODISPATCH_REPO_ALLOWLIST` | CSV of `owner/name` | `antonio-mello-ai/crewdock` | GitHub repo identifiers, **not** filesystem paths. Must include `WORKFLOW.md` `tracker.repo`. |
-| `AIOS_AGENT_AUTODISPATCH_WORKFLOW_ALLOWLIST` | CSV of blueprint ids | `development-blueprint-v0` | Must match `cb_workflow_blueprints.id` exactly. v5 (#95) lets you create blueprints with stable client-supplied ids. |
+| `AIOS_AGENT_AUTODISPATCH_WORKFLOW_ALLOWLIST` | CSV of blueprint ids | `development-blueprint-v0` | Must match `cb_workflow_blueprints.id` exactly. Use `POST /workflow-blueprints` with body `{ "id": "<stable-id>", ... }` to create a blueprint with a stable, allowlist-friendly id (regex `/^[a-z0-9][a-z0-9._-]{1,62}$/`). Omitting `id` falls back to a generated nanoid (legacy behavior). |
 | `AIOS_AGENT_AUTODISPATCH_AREA_ALLOWLIST` | CSV of `CompanyBrainArea` | `development,platform` | Allowed values: `strategy`, `development`, `operations`, `product`, `marketing`, `sales`, `finance`, `people`, `customer`, `platform`. |
 | `AIOS_AGENT_AUTODISPATCH_REQUIRE_RISK_A` | boolean string | `true` | When `true` (default), only Risk A WorkItems are eligible. Set `false` to allow Risk B with documented rationale. |
 | `AIOS_AGENT_AUTODISPATCH_MAX_CONCURRENCY` | int | `1` | Max active runs at any time across the daemon. Defaults to 1; the loop also enforces single-run-per-tick. |

--- a/packages/daemon/src/routes/company-brain.ts
+++ b/packages/daemon/src/routes/company-brain.ts
@@ -25227,13 +25227,50 @@ app.get("/workflow-blueprints", (c) => {
   return c.json({ data, total: data.length });
 });
 
+const STABLE_BLUEPRINT_ID_REGEX = /^[a-z0-9][a-z0-9._-]{1,62}$/;
+
 app.post("/workflow-blueprints", async (c) => {
   try {
     const body = await c.req.json<CreateWorkflowBlueprintRequest>();
     const timestamp = now();
     const stages = body.stages ?? [];
+
+    let resolvedId = nanoid(12);
+    let stableIdRequested = false;
+    if (body.id !== undefined && body.id !== null && body.id !== "") {
+      stableIdRequested = true;
+      const candidate = String(body.id).trim();
+      if (!STABLE_BLUEPRINT_ID_REGEX.test(candidate)) {
+        return c.json(
+          {
+            error: "validation",
+            message:
+              "id must match /^[a-z0-9][a-z0-9._-]{1,62}$/ (lowercase, alphanumeric, dot/dash/underscore, 2-63 chars)",
+            data: { receivedId: body.id },
+          },
+          400
+        );
+      }
+      const existing = getDb()
+        .select()
+        .from(cbWorkflowBlueprints)
+        .where(eq(cbWorkflowBlueprints.id, candidate))
+        .get();
+      if (existing) {
+        return c.json(
+          {
+            error: "id_collision",
+            message: `workflow blueprint id ${candidate} already exists; pick a different stable id or PATCH the existing blueprint`,
+            data: { existingId: candidate },
+          },
+          409
+        );
+      }
+      resolvedId = candidate;
+    }
+
     const row = {
-      id: nanoid(12),
+      id: resolvedId,
       title: requireText(body.title, "title"),
       description: body.description ?? null,
       workflowArea: body.workflowArea ?? "unknown",
@@ -25252,7 +25289,10 @@ app.post("/workflow-blueprints", async (c) => {
       updatedAt: timestamp,
     };
     getDb().insert(cbWorkflowBlueprints).values(row).run();
-    return c.json({ data: row }, 201);
+    return c.json(
+      { data: row, meta: { stableIdHonored: stableIdRequested } },
+      201
+    );
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";
     return c.json({ error: "create_failed", message }, 400);

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -2344,6 +2344,15 @@ export interface WorkflowBlueprint {
 }
 
 export interface CreateWorkflowBlueprintRequest {
+  /**
+   * Optional stable client-supplied identity. When provided, becomes the
+   * cb_workflow_blueprints.id directly so operators can reference it from
+   * AIOS_AGENT_AUTODISPATCH_WORKFLOW_ALLOWLIST. Must match
+   * /^[a-z0-9][a-z0-9._-]{1,62}$/ (lowercase, alphanumeric, dot/dash/
+   * underscore, 2-63 chars). Collisions return 409. Omit to fall back to
+   * a generated nanoid (legacy behavior).
+   */
+  id?: string;
   title: string;
   description?: string | null;
   workflowArea?: CompanyBrainArea;


### PR DESCRIPTION
## Summary

Closes #95

AIOS-RUN-25: addresses v4 dogfood friction #2 — `POST /workflow-blueprints` now accepts an optional stable client-supplied `id` so operators can reference blueprints by name from `AIOS_AGENT_AUTODISPATCH_WORKFLOW_ALLOWLIST`.

### Contract

`CreateWorkflowBlueprintRequest.id?: string`

| Path | Behavior |
|---|---|
| `id` omitted | Falls back to `nanoid(12)` (legacy behavior) |
| `id` provided + valid + free | Uses it as `cb_workflow_blueprints.id`; response has `meta.stableIdHonored=true` |
| `id` invalid format | 400 with regex `/^[a-z0-9][a-z0-9._-]{1,62}$/` in message |
| `id` collides | 409 `id_collision` with `existingId` |

### Backward compat

- Seeded `development-blueprint-v0` keeps its id and remains valid.
- Existing API clients omitting `id` see no behavior change.
- `workflow_allowed` gate still reports `matchedRefs` in the detail string so allowlist diagnostics remain accurate.

### Test plan

- [x] `npx turbo build` clean.
- [x] `POST { "id": "aios-supervised-runner-v0", "title": "..." }` → 201 with that id and `meta.stableIdHonored=true`.
- [x] Same id again → 409 `id_collision` with `existingId`.
- [x] `id: "BAD ID"` → 400 `validation` with regex.
- [x] No `id` field → 201 with 12-char nanoid and `meta.stableIdHonored=false`.
- [x] Restart with `AIOS_AGENT_AUTODISPATCH_WORKFLOW_ALLOWLIST=aios-supervised-runner-v0` → `workflow_allowed` gate passes with `detail="Allowlisted blueprint refs registered: [aios-supervised-runner-v0]"`.
- [ ] Production smoke after deploy: confirm 400/409 paths on `https://api.felhen.ai`.

### Constraints honored

- No idempotent migration needed (existing schema already has `id` as PRIMARY KEY).
- No external writeback, new secret, paid service, auto-merge, auto-deploy, or broad auto-dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)