### PR TITLE
feat: workspace cleanup risk review ux v5

### DIFF
--- a/packages/daemon/src/routes/company-brain.ts
+++ b/packages/daemon/src/routes/company-brain.ts
@@ -15537,6 +15537,66 @@ app.get("/agent-runs/:id/workspace/cleanup-preview", (c) => {
     !summary.risks.some(
       (r) => r.kind === "path_outside_root" || r.kind === "agent_run_active"
     );
+  // Derive a single combined review state operators can read at a glance.
+  const hasPathRisk = summary.risks.some((r) => r.kind === "path_outside_root");
+  const hasActiveRunRisk = summary.risks.some(
+    (r) => r.kind === "agent_run_active"
+  );
+  const hasMissingWorktree = summary.risks.some(
+    (r) => r.kind === "missing_worktree"
+  );
+  const hasOtherRisks =
+    summary.risks.length > 0 &&
+    !hasPathRisk &&
+    !hasActiveRunRisk;
+
+  let reviewStatus: "clear" | "needs_review" | "blocked";
+  let reviewSummary: string;
+  let recommendedAction:
+    | "proceed_remove"
+    | "proceed_quarantine"
+    | "inspect_dirty_changes"
+    | "wait_for_run"
+    | "verify_path_root"
+    | "noop_already_clean";
+
+  if (!summary.workspaceExists) {
+    reviewStatus = "clear";
+    reviewSummary =
+      "Workspace path does not exist. Cleanup is a noop; nothing to inspect.";
+    recommendedAction = "noop_already_clean";
+  } else if (hasPathRisk) {
+    reviewStatus = "blocked";
+    reviewSummary =
+      "Path escapes the configured workspace root. Cleanup refused for safety.";
+    recommendedAction = "verify_path_root";
+  } else if (hasActiveRunRisk) {
+    reviewStatus = "blocked";
+    reviewSummary =
+      "AgentRun is still queued/claimed/running. Cancel or wait for terminal status before cleanup.";
+    recommendedAction = "wait_for_run";
+  } else if (summary.isDirty) {
+    reviewStatus = "needs_review";
+    reviewSummary = hasMissingWorktree
+      ? "Workspace contains uncommitted changes AND worktree was never registered. Inspect changes or quarantine."
+      : "Workspace contains uncommitted changes. Inspect with `git -C <path> status` before destructive remove.";
+    recommendedAction = "inspect_dirty_changes";
+  } else if (hasMissingWorktree) {
+    reviewStatus = "needs_review";
+    reviewSummary =
+      "Workspace exists but worktree was never registered with `git worktree add`. Quarantine recommended; remove will fall back to rmSync only.";
+    recommendedAction = "proceed_quarantine";
+  } else if (hasOtherRisks) {
+    reviewStatus = "needs_review";
+    reviewSummary = `Risks present: ${summary.risks.map((r) => r.kind).join(", ")}. Review before destructive remove.`;
+    recommendedAction = "proceed_quarantine";
+  } else {
+    reviewStatus = "clear";
+    reviewSummary =
+      "Workspace is clean, run is terminal, no risks. Safe to remove with confirmation token.";
+    recommendedAction = "proceed_remove";
+  }
+
   const response: WorkspaceCleanupPreviewResponse = {
     generatedAt: now(),
     agentRunId: id,
@@ -15555,6 +15615,9 @@ app.get("/agent-runs/:id/workspace/cleanup-preview", (c) => {
       : quarantineAllowed
         ? "Workspace is dirty or has missing worktree; quarantine allowed but destructive remove blocked unless allowDirty=true."
         : "Cleanup blocked. Resolve risks (path safety / dirty / active run) before continuing.",
+    reviewStatus,
+    reviewSummary,
+    recommendedAction,
   };
   return c.json({ data: response });
 });

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1170,6 +1170,11 @@ export type WorkspaceCleanupRisk =
   | "agent_run_active"
   | "missing_worktree";
 
+export type WorkspaceCleanupReviewStatus =
+  | "clear"
+  | "needs_review"
+  | "blocked";
+
 export interface WorkspaceCleanupPreviewResponse {
   generatedAt: number;
   agentRunId: string;
@@ -1184,6 +1189,32 @@ export interface WorkspaceCleanupPreviewResponse {
   quarantineAllowed: boolean;
   expectedConfirmationToken: string;
   policySummary: string;
+  /**
+   * Combined review state derived from risks + isDirty + agentRunStatus +
+   * workspaceExists. `clear` = no risks and workspace is in a known-safe
+   * shape; `needs_review` = at least one risk requires operator review
+   * before destructive action; `blocked` = cleanup not allowed because the
+   * agent run is still running/queued or the workspace path escapes the
+   * configured root.
+   */
+  reviewStatus: WorkspaceCleanupReviewStatus;
+  /**
+   * Short human-readable explanation of `reviewStatus`. Mirrors the
+   * console copy so MCP consumers and CLI operators see the same hint.
+   */
+  reviewSummary: string;
+  /**
+   * Recommended next action for the operator: `proceed_remove`,
+   * `proceed_quarantine`, `inspect_dirty_changes`, `wait_for_run`,
+   * `verify_path_root` or `noop_already_clean`.
+   */
+  recommendedAction:
+    | "proceed_remove"
+    | "proceed_quarantine"
+    | "inspect_dirty_changes"
+    | "wait_for_run"
+    | "verify_path_root"
+    | "noop_already_clean";
 }
 
 export interface QuarantineWorkspaceRequest {


### PR DESCRIPTION
## Summary

Closes #96

AIOS-RUN-26: addresses v4 dogfood friction #3. Cleanup preview response gains a single combined review state plus a recommended action so operators no longer have to inspect multiple raw arrays (`risks[]`, `isDirty`, `agentRunStatus`, `workspaceExists`) to know whether cleanup is safe.

### Response shape additions (backwards-compatible)

| Field | Type | Purpose |
|---|---|---|
| `reviewStatus` | `"clear" \| "needs_review" \| "blocked"` | Combined state |
| `reviewSummary` | string | Short human-readable explanation |
| `recommendedAction` | `"proceed_remove" \| "proceed_quarantine" \| "inspect_dirty_changes" \| "wait_for_run" \| "verify_path_root" \| "noop_already_clean"` | Operator's next move |

Existing fields (`cleanupAllowed`, `quarantineAllowed`, `policySummary`, `expectedConfirmationToken`, raw `risks[]`) are preserved untouched.

### Decision priority (highest first)

1. Workspace missing → `clear` / `noop_already_clean`
2. `path_outside_root` risk → `blocked` / `verify_path_root` (safety wins, regardless of other risks)
3. `agent_run_active` risk → `blocked` / `wait_for_run`
4. `isDirty` → `needs_review` / `inspect_dirty_changes` (with note when also `missing_worktree`)
5. `missing_worktree` only → `needs_review` / `proceed_quarantine`
6. Other risks present → `needs_review` / `proceed_quarantine`
7. Clean + terminal + no risks → `clear` / `proceed_remove`

### Test plan

- [x] `npx turbo build` clean.
- [x] **Workspace missing**: `reviewStatus=clear`, `recommendedAction=noop_already_clean`.
- [x] **Path outside root**: `reviewStatus=blocked`, `recommendedAction=verify_path_root` (even with other risks like `agent_run_active`).
- [x] **Running AgentRun + safe path**: `reviewStatus=blocked`, `recommendedAction=wait_for_run`.
- [x] **Real git worktree, terminal, no risks**: `reviewStatus=clear`, `recommendedAction=proceed_remove`.
- [ ] Production smoke after deploy: confirm response shape on `https://api.felhen.ai`.

### Constraints honored

- Existing destructive cleanup confirmation token still required.
- No cleanup outside the configured AIOS workspace root.
- No external writeback, new secret, paid service, auto-merge, auto-deploy, or broad auto-dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)