### PR TITLE
feat: internal audited workitem status update path v5

### DIFF
--- a/packages/daemon/src/routes/company-brain.ts
+++ b/packages/daemon/src/routes/company-brain.ts
@@ -105,6 +105,8 @@ import type {
   OperatingLoopReconciliationOutcome,
   PromoteAgentRunSuggestionRequest,
   PromoteAgentRunSuggestionResponse,
+  UpdateWorkItemStatusRequest,
+  UpdateWorkItemStatusResponse,
   CreateAgentRunRequest,
   UpdateAgentRunRequest,
   DecomposeOperatingGoalRequest,
@@ -22259,6 +22261,162 @@ app.post("/work-items", async (c) => {
     const message = err instanceof Error ? err.message : "Unknown error";
     return c.json({ error: "create_failed", message }, 400);
   }
+});
+
+const ALLOWED_WORK_ITEM_STATUS_VALUES: ReadonlyArray<WorkItemStatus> = [
+  "new",
+  "triage",
+  "planned",
+  "in_progress",
+  "review",
+  "blocked",
+  "done",
+  "cancelled",
+];
+
+app.patch("/work-items/:id/status", async (c) => {
+  const id = c.req.param("id");
+  const body = (await c.req
+    .json<UpdateWorkItemStatusRequest>()
+    .catch(() => ({}))) as UpdateWorkItemStatusRequest;
+  if (!body.actor || !body.actor.trim()) {
+    return c.json({ error: "validation", message: "actor is required" }, 400);
+  }
+  if (!body.rationale || !body.rationale.trim()) {
+    return c.json(
+      { error: "validation", message: "rationale is required" },
+      400
+    );
+  }
+  if (!body.status || !ALLOWED_WORK_ITEM_STATUS_VALUES.includes(body.status)) {
+    return c.json(
+      {
+        error: "validation",
+        message: `status must be one of [${ALLOWED_WORK_ITEM_STATUS_VALUES.join(",")}]`,
+      },
+      400
+    );
+  }
+  if (body.status === "blocked" && !body.blockedReason?.trim()) {
+    return c.json(
+      {
+        error: "validation",
+        message: "blockedReason is required when status=blocked",
+      },
+      400
+    );
+  }
+
+  const db = getDb();
+  const existing = db
+    .select()
+    .from(cbWorkItems)
+    .where(eq(cbWorkItems.id, id))
+    .get() as WorkItem | undefined;
+  if (!existing) {
+    return c.json(
+      { error: "not_found", message: `work item ${id} not found` },
+      404
+    );
+  }
+
+  const previousStatus = existing.status;
+  const timestamp = now();
+  const internalOverride =
+    existing.externalProvider === "github" && existing.externalId
+      ? true
+      : false;
+
+  // Resolve or create the synthetic source for internal status updates so
+  // the audit Artifact has a stable provenance pointer.
+  const sourceArea: CompanyBrainArea = existing.area;
+  const sourceVisibility: Visibility = existing.visibility ?? "internal";
+  const auditSourceId = ensureSessionResultsSource(
+    sourceArea,
+    sourceVisibility,
+    timestamp
+  );
+
+  const artifactId = nanoid(12);
+  const rawRef = `aios://work-item-status-update/${id}/${timestamp}`;
+  const auditTitle = `WorkItem status: ${previousStatus} -> ${body.status} (${existing.title.slice(0, 80)})`;
+  const auditMetadata: Record<string, unknown> = {
+    workItemId: id,
+    previousStatus,
+    newStatus: body.status,
+    actor: body.actor.trim(),
+    rationale: body.rationale.trim(),
+    internalOverride,
+    blockedReason: body.blockedReason ?? null,
+    reviewNote: body.reviewNote ?? null,
+  };
+  if (internalOverride) {
+    auditMetadata.externalRef = existing.externalId;
+    auditMetadata.note =
+      "Internal-only status override; GitHub issue was NOT mutated. Sync GitHub Issues to reconcile if needed.";
+  }
+  const auditRow: Artifact = {
+    id: artifactId,
+    sourceId: auditSourceId,
+    artifactType: "session_result",
+    area: existing.area,
+    title: auditTitle,
+    summary: `Internal status update for WorkItem ${id} by ${body.actor.trim()}: ${body.rationale.trim().slice(0, 200)}`,
+    contentRef: null,
+    rawRef,
+    author: body.actor.trim(),
+    occurredAt: timestamp,
+    ingestedAt: timestamp,
+    hash: createHash("sha256")
+      .update(JSON.stringify({ id, previousStatus, newStatus: body.status, timestamp }))
+      .digest("hex"),
+    visibility: sourceVisibility,
+    provenance: {
+      sourceId: auditSourceId,
+      rawRef,
+      artifactId,
+      createdFrom: "company_brain:work_item_status_update",
+      confidence: 1,
+      extractedAt: timestamp,
+      humanReviewStatus: "approved",
+      visibility: sourceVisibility,
+      notes: `actor=${body.actor.trim()}; status=${previousStatus}->${body.status}; internalOverride=${internalOverride}`,
+    },
+    humanReviewStatus: "approved",
+    confidence: 1,
+    metadata: auditMetadata,
+  };
+  db.insert(cbArtifacts).values(auditRow as never).run();
+
+  // Update the WorkItem.
+  const updates: Record<string, unknown> = {
+    status: body.status,
+    updatedAt: timestamp,
+  };
+  if (body.status === "blocked") {
+    updates.blockedReason = body.blockedReason!.trim();
+  } else if (previousStatus === ("blocked" as WorkItemStatus)) {
+    updates.blockedReason = null;
+  }
+  db.update(cbWorkItems)
+    .set(updates as never)
+    .where(eq(cbWorkItems.id, id))
+    .run();
+
+  const refreshed = db
+    .select()
+    .from(cbWorkItems)
+    .where(eq(cbWorkItems.id, id))
+    .get() as WorkItem;
+
+  const response: UpdateWorkItemStatusResponse = {
+    generatedAt: timestamp,
+    workItem: refreshed,
+    previousStatus,
+    internalOverride,
+    artifactId,
+  };
+  return c.json({ data: response });
 });
 
 app.post("/extractors/artifact-insights", async (c) => {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1647,6 +1647,42 @@ server.registerTool(
 );
 
 server.registerTool(
+  "update_company_brain_work_item_status",
+  {
+    title: "Update Company Brain WorkItem status (internal, audited)",
+    description:
+      "Update a WorkItem.status with actor + rationale. Creates an audit Artifact (session_result type) recording previous->new status, internalOverride flag (when WorkItem is GitHub-sourced), and rationale. Does NOT mutate GitHub issues — internal-only override.",
+    inputSchema: {
+      workItemId: z.string().min(1),
+      actor: z.string().min(1),
+      rationale: z.string().min(1),
+      status: z.enum([
+        "new",
+        "triage",
+        "planned",
+        "in_progress",
+        "review",
+        "blocked",
+        "done",
+        "cancelled",
+      ]),
+      blockedReason: z.string().optional(),
+      reviewNote: z.string().optional(),
+    },
+  },
+  async ({ workItemId, ...rest }) => {
+    const result = await daemonFetch<{ data: unknown }>(
+      `/api/company-brain/work-items/${workItemId}/status`,
+      {
+        method: "PATCH",
+        body: JSON.stringify(rest),
+      }
+    );
+    return formatJsonResult(result.data);
+  }
+);
+
+server.registerTool(
   "promote_company_brain_agent_run_suggestion",
   {
     title: "Promote Company Brain AgentRun suggestion",

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -2374,6 +2374,22 @@ export interface WorkflowBlueprint {
   updatedAt: number;
 }
 
+export interface UpdateWorkItemStatusRequest {
+  actor: string;
+  rationale: string;
+  status: WorkItemStatus;
+  blockedReason?: string | null;
+  reviewNote?: string | null;
+}
+
+export interface UpdateWorkItemStatusResponse {
+  generatedAt: number;
+  workItem: WorkItem;
+  previousStatus: WorkItemStatus;
+  internalOverride: boolean;
+  artifactId: string;
+}
+
 export interface CreateWorkflowBlueprintRequest {
   /**
    * Optional stable client-supplied identity. When provided, becomes the


### PR DESCRIPTION
## Summary

Closes #97

AIOS-RUN-27: addresses v4 dogfood friction #4. Adds a narrow `PATCH /work-items/:id/status` endpoint with actor + rationale audit and provenance Artifact, without mutating any external GitHub issue.

### Endpoint contract

```
PATCH /api/company-brain/work-items/:id/status
{
  actor: string,           // required
  rationale: string,       // required
  status: WorkItemStatus,  // required, in [new, triage, planned, in_progress,
                           //               review, blocked, done, cancelled]
  blockedReason?: string,  // required when status=blocked
  reviewNote?: string      // optional human comment
}
```

### Behavior

1. Validates actor + rationale + status enum + blockedReason when status=blocked. 400 on each missing field with explicit message.
2. 404 when WorkItem.id not found.
3. Creates a `session_result` Artifact recording previousStatus, newStatus, actor, rationale, internalOverride, blockedReason, reviewNote, externalRef (when GitHub-sourced).
4. Updates WorkItem.status. When status=blocked, persists blockedReason; when unblocking, clears it automatically.
5. Marks `internalOverride=true` when WorkItem.externalProvider=github AND externalId is set; the audit Artifact carries a note that GitHub issue was NOT mutated.

### Response

```
{ generatedAt, workItem, previousStatus, internalOverride, artifactId }
```

### MCP tool

`update_company_brain_work_item_status` with the same fields.

### Test plan

- [x] `npx turbo build` clean.
- [x] Internal WI `new -> in_progress`: `internalOverride=false`, `artifactId` set.
- [x] `status=blocked` without `blockedReason`: 400.
- [x] `status=blocked` with reason: `blockedReason` persisted.
- [x] Unblock `blocked -> done`: `blockedReason` cleared automatically.
- [x] GitHub-sourced WI: `internalOverride=true`, audit artifact carries externalRef and "NOT mutated" note.
- [x] Missing actor / bad status / unknown id: each returns explicit validation error.
- [x] 4 audit artifacts produced with full status transition trail visible via `session_result` type.
- [ ] Production smoke after deploy.

### Constraints honored

- Does NOT close/reopen/comment/label GitHub or any external tracker.
- GitHub Issue sync remains authoritative; `internalOverride` flag makes overrides visible.
- No new secret, paid service, external writeback, auto-merge, auto-deploy, or broad auto-dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)