### PR TITLE
feat: agent runner profile registry v6

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -90,6 +90,22 @@ Auto-dispatch is **default-off** in production. Opt-in requires the following en
 | `AIOS_AGENT_AUTODISPATCH_DEFAULT_ACTOR` | string | `operating-loop:auto-dispatch` | Audit actor for promote + execute-async calls. |
 | `AIOS_AGENT_AUTODISPATCH_DEFAULT_RATIONALE` | string | `Auto-dispatched by Operating Loop after eligibility evaluation` | Default rationale recorded on AgentRun. |
 | `AIOS_AGENT_AUTODISPATCH_COMMAND_OVERRIDE` | string (optional) | `echo` | When set, auto-dispatch passes this binary as `commandOverride` to `/execute-async` instead of `WORKFLOW.md` `agent.command`. Must still be present in `AIOS_AGENT_RUNNER_COMMAND_ALLOWLIST`. Useful for dogfood smoke runs with benign commands. |
+| `AIOS_AGENT_AUTODISPATCH_PROFILE_ID` | runner profile id (optional) | `noop-echo` | Selects a typed runner profile from the registry (`GET /runner-profiles`). Takes precedence over `COMMAND_OVERRIDE`. Profile's `command`/`args` thread through to `/execute-async`. Eligibility additionally checks the profile is enabled and that repo/area/risk are within profile bounds. |
+| `AIOS_AGENT_RUNNER_PROFILE_CLAUDE_CODE_ENABLED` | boolean string (optional) | `false` | Toggles the `claude-code-real` runner profile. Default-OFF. |
+| `AIOS_AGENT_RUNNER_PROFILE_CODEX_CLI_ENABLED` | boolean string (optional) | `false` | Toggles the `codex-cli-real` runner profile. Default-OFF. |
+
+## Runner profile registry
+
+Built-in profiles queryable via `GET /runner-profiles?repo=...&area=...&riskClass=...`:
+
+| id | category | command | defaultEnabled | risk ceiling | capabilities |
+|---|---|---|---|---|---|
+| `noop-echo` | noop | `echo aios-noop-runner-heartbeat` | true | A | `no_op` |
+| `dogfood-true` | dogfood | `true` | true | A | `no_op` |
+| `claude-code-real` | real_agent | `claude -p` | false | B | `shell_command`, `code_edit`, `git_commit`, `github_pr_open`, `test_runner` |
+| `codex-cli-real` | real_agent | `codex` | false | B | same as `claude-code-real` |
+
+Real-agent profiles are explicitly OFF by default. Each carries an `enabledEnvVar` the operator must set to `true` before the profile becomes selectable. The eligibility evaluator chains the runner profile gate after all other auto-dispatch gates so policy hints stay specific.
 
 ## Manual runner env vars
 

--- a/packages/daemon/src/routes/company-brain.ts
+++ b/packages/daemon/src/routes/company-brain.ts
@@ -101,10 +101,13 @@ import type {
   AgentRunReconciliationFinding,
   EvaluateAutoDispatchEligibilityRequest,
   ListAgentRunSuggestionsResponse,
+  ListRunnerProfilesResponse,
   OperatingLoopAutoDispatchOutcome,
   OperatingLoopReconciliationOutcome,
   PromoteAgentRunSuggestionRequest,
   PromoteAgentRunSuggestionResponse,
+  RunnerProfile,
+  RunnerProfileEvaluation,
   UpdateWorkItemStatusRequest,
   UpdateWorkItemStatusResponse,
   CreateAgentRunRequest,
@@ -12666,6 +12669,202 @@ function csvEnv(value: string | undefined): string[] {
     .filter((v) => v.length > 0);
 }
 
+const RUNNER_PROFILE_REGISTRY: RunnerProfile[] = [
+  {
+    id: "noop-echo",
+    title: "Noop echo",
+    description:
+      "Pure shell echo profile for dogfood smoke tests. Always allowed when AIOS_AGENT_RUNNER_ENABLED=true and `echo` is in COMMAND_ALLOWLIST. Produces no real output beyond a heartbeat line and exits 0.",
+    command: "echo",
+    args: ["aios-noop-runner-heartbeat"],
+    capabilities: ["no_op"],
+    authMode: "none",
+    allowedRepos: "*",
+    allowedAreas: "*",
+    maxConcurrency: 1,
+    riskCeiling: "A",
+    outputContract: {
+      format: "noop",
+      expectedExitCodes: [0],
+      description: "Single stdout line; no session_result schema enforced.",
+    },
+    defaultEnabled: true,
+    category: "noop",
+  },
+  {
+    id: "dogfood-true",
+    title: "Dogfood true",
+    description:
+      "Single-call `true` for the most minimal subprocess test. Useful when smoke needs to validate the dispatch chain without producing any output.",
+    command: "true",
+    args: [],
+    capabilities: ["no_op"],
+    authMode: "none",
+    allowedRepos: "*",
+    allowedAreas: "*",
+    maxConcurrency: 1,
+    riskCeiling: "A",
+    outputContract: {
+      format: "noop",
+      expectedExitCodes: [0],
+      description: "Empty stdout, exit 0.",
+    },
+    defaultEnabled: true,
+    category: "dogfood",
+  },
+  {
+    id: "claude-code-real",
+    title: "Claude Code (real agent)",
+    description:
+      "Production Claude Code CLI. Edits files, opens PRs, runs tests. Requires Anthropic API key. Default-OFF; enable explicitly via AIOS_AGENT_RUNNER_PROFILE_CLAUDE_CODE_ENABLED.",
+    command: "claude",
+    args: ["-p"],
+    capabilities: [
+      "shell_command",
+      "code_edit",
+      "git_commit",
+      "github_pr_open",
+      "test_runner",
+    ],
+    authMode: "anthropic_api_key",
+    allowedRepos: ["antonio-mello-ai/crewdock"],
+    allowedAreas: ["development", "platform"],
+    maxConcurrency: 1,
+    riskCeiling: "B",
+    outputContract: {
+      format: "fallback",
+      expectedExitCodes: [0, 1],
+      description:
+        "Last lines of stdout parsed as session_result fallback when structured JSON is absent.",
+    },
+    defaultEnabled: false,
+    enabledEnvVar: "AIOS_AGENT_RUNNER_PROFILE_CLAUDE_CODE_ENABLED",
+    category: "real_agent",
+  },
+  {
+    id: "codex-cli-real",
+    title: "Codex CLI (real agent)",
+    description:
+      "OpenAI Codex CLI. Same capability surface as Claude Code. Default-OFF; enable explicitly via AIOS_AGENT_RUNNER_PROFILE_CODEX_CLI_ENABLED.",
+    command: "codex",
+    args: [],
+    capabilities: [
+      "shell_command",
+      "code_edit",
+      "git_commit",
+      "github_pr_open",
+      "test_runner",
+    ],
+    authMode: "openai_api_key",
+    allowedRepos: ["antonio-mello-ai/crewdock"],
+    allowedAreas: ["development", "platform"],
+    maxConcurrency: 1,
+    riskCeiling: "B",
+    outputContract: {
+      format: "fallback",
+      expectedExitCodes: [0, 1],
+      description:
+        "Codex stdout parsed via fallback session_result extraction.",
+    },
+    defaultEnabled: false,
+    enabledEnvVar: "AIOS_AGENT_RUNNER_PROFILE_CODEX_CLI_ENABLED",
+    category: "real_agent",
+  },
+];
+
+function getRunnerProfile(id: string): RunnerProfile | null {
+  return RUNNER_PROFILE_REGISTRY.find((p) => p.id === id) ?? null;
+}
+
+function isRunnerProfileEnabled(profile: RunnerProfile): boolean {
+  if (profile.defaultEnabled) return true;
+  if (profile.enabledEnvVar) {
+    return process.env[profile.enabledEnvVar] === "true";
+  }
+  return false;
+}
+
+function evaluateRunnerProfile(args: {
+  profileId: string;
+  repo?: string | null;
+  area?: CompanyBrainArea | null;
+  riskClass?: RiskClass | null;
+}): RunnerProfileEvaluation {
+  const profile = getRunnerProfile(args.profileId);
+  if (!profile) {
+    return {
+      profileId: args.profileId,
+      available: false,
+      reason: "profile_not_found",
+      detail: `Runner profile "${args.profileId}" is not registered. Known: ${RUNNER_PROFILE_REGISTRY.map((p) => p.id).join(", ")}.`,
+    };
+  }
+  if (!isRunnerProfileEnabled(profile)) {
+    return {
+      profileId: profile.id,
+      available: false,
+      reason: "profile_not_enabled",
+      detail: `Profile "${profile.id}" is default-OFF; opt-in required.`,
+      enabledEnvVar: profile.enabledEnvVar,
+    };
+  }
+  const cmdAllowlist = runnerCommandAllowlist();
+  if (!cmdAllowlist.includes(profile.command)) {
+    return {
+      profileId: profile.id,
+      available: false,
+      reason: "profile_command_not_allowlisted",
+      detail: `Profile command ${profile.command} is not in AIOS_AGENT_RUNNER_COMMAND_ALLOWLIST=[${cmdAllowlist.join(",")}].`,
+      enabledEnvVar: profile.enabledEnvVar,
+    };
+  }
+  if (
+    args.repo &&
+    profile.allowedRepos !== "*" &&
+    !profile.allowedRepos.includes(args.repo)
+  ) {
+    return {
+      profileId: profile.id,
+      available: false,
+      reason: "profile_repo_not_allowed",
+      detail: `Profile "${profile.id}" does not allow repo=${args.repo}; allowed=[${profile.allowedRepos.join(",")}].`,
+    };
+  }
+  if (
+    args.area &&
+    profile.allowedAreas !== "*" &&
+    !(profile.allowedAreas as string[]).includes(args.area)
+  ) {
+    return {
+      profileId: profile.id,
+      available: false,
+      reason: "profile_area_not_allowed",
+      detail: `Profile "${profile.id}" does not allow area=${args.area}; allowed=[${(profile.allowedAreas as string[]).join(",")}].`,
+    };
+  }
+  // riskCeiling: A is most restrictive (only A allowed), B allows A or B,
+  // C allows everything (we never use C here).
+  if (args.riskClass) {
+    const riskOrder: Record<string, number> = { A: 1, B: 2, C: 3, unknown: 99 };
+    const requested = riskOrder[args.riskClass] ?? 99;
+    const ceiling = riskOrder[profile.riskCeiling] ?? 0;
+    if (requested > ceiling) {
+      return {
+        profileId: profile.id,
+        available: false,
+        reason: "profile_risk_ceiling_exceeded",
+        detail: `Profile "${profile.id}" risk ceiling=${profile.riskCeiling}; requested=${args.riskClass}.`,
+      };
+    }
+  }
+  return {
+    profileId: profile.id,
+    available: true,
+    reason: null,
+    detail: `Profile "${profile.id}" available (command=${profile.command}, capabilities=[${profile.capabilities.join(",")}]).`,
+  };
+}
+
 function autoDispatchEnabled(): boolean {
   return process.env.AIOS_AGENT_AUTODISPATCH_ENABLED === "true";
 }
@@ -12712,6 +12911,8 @@ function autoDispatchConfig(): AutoDispatchPolicyConfig {
       "Auto-dispatched by Operating Loop after eligibility evaluation",
     commandOverride:
       process.env.AIOS_AGENT_AUTODISPATCH_COMMAND_OVERRIDE?.trim() || null,
+    profileId:
+      process.env.AIOS_AGENT_AUTODISPATCH_PROFILE_ID?.trim() || null,
   };
 }
 
@@ -13156,6 +13357,16 @@ function evaluateAutoDispatchEligibility(args: {
       createdAt: now(),
       updatedAt: now(),
     } as unknown as typeof cbAgentRuns.$inferSelect;
+    // Resolve effective command for the chained manual policy. Profile
+    // selection takes precedence over commandOverride.
+    let effectiveCommandOverride: string | undefined =
+      config.commandOverride ?? undefined;
+    if (config.profileId) {
+      const profile = getRunnerProfile(config.profileId);
+      if (profile) {
+        effectiveCommandOverride = profile.command;
+      }
+    }
     try {
       const policy = evaluateRunnerPolicy({
         agentRun: syntheticRun,
@@ -13163,7 +13374,7 @@ function evaluateAutoDispatchEligibility(args: {
           intent: "real_execution",
           actor: args.actorOverride ?? config.defaultActor,
           rationale: args.rationaleOverride ?? config.defaultRationale,
-          commandOverride: config.commandOverride ?? undefined,
+          commandOverride: effectiveCommandOverride,
         },
       });
       manualRunnerPolicyDecision = policy.decision;
@@ -13335,6 +13546,58 @@ function evaluateAutoDispatchEligibility(args: {
     satisfiedGates.push("actor_rationale_present");
   }
 
+  // 12. Runner profile (optional — only enforced when profileId is set).
+  if (config.profileId) {
+    const profileEval = evaluateRunnerProfile({
+      profileId: config.profileId,
+      repo,
+      area: args.workItem?.area ?? null,
+      riskClass: args.workItem?.riskClass ?? null,
+    });
+    if (!profileEval.available) {
+      gates.push({
+        key: "runner_profile_available",
+        title: "Runner profile available",
+        status: "failed",
+        detail: profileEval.detail,
+        remediation: profileEval.enabledEnvVar
+          ? `Set ${profileEval.enabledEnvVar}=true to enable this profile, or pick a different AIOS_AGENT_AUTODISPATCH_PROFILE_ID.`
+          : "Pick a registered, enabled profile via AIOS_AGENT_AUTODISPATCH_PROFILE_ID.",
+        envRefs: profileEval.enabledEnvVar
+          ? [
+              "AIOS_AGENT_AUTODISPATCH_PROFILE_ID",
+              profileEval.enabledEnvVar,
+            ]
+          : ["AIOS_AGENT_AUTODISPATCH_PROFILE_ID"],
+        expectedFormat: "Registered runner profile id (see GET /runner-profiles)",
+        exampleValue: "noop-echo",
+        docsLink: "WORKFLOW.md#runner-profile-registry",
+      });
+      blockReasons.push(`autodispatch_profile_${profileEval.reason ?? "unavailable"}`);
+      setBlock("blocked_runner_policy");
+    } else {
+      gates.push({
+        key: "runner_profile_available",
+        title: "Runner profile available",
+        status: "passed",
+        detail: profileEval.detail,
+      });
+      satisfiedGates.push("runner_profile_available");
+    }
+  } else {
+    gates.push({
+      key: "runner_profile_available",
+      title: "Runner profile available",
+      status: "warn",
+      detail:
+        "No AIOS_AGENT_AUTODISPATCH_PROFILE_ID set; falling back to commandOverride or WORKFLOW.md agent.command. Set a profile id for typed runner selection.",
+      envRefs: ["AIOS_AGENT_AUTODISPATCH_PROFILE_ID"],
+      expectedFormat: "Registered runner profile id (see GET /runner-profiles)",
+      exampleValue: "noop-echo",
+      docsLink: "WORKFLOW.md#runner-profile-registry",
+    });
+  }
+
   const decision: AutoDispatchDecision = firstBlockDecision ?? "eligible";
   const eligible = decision === "eligible" && !blockReasons.length;
 
@@ -13393,6 +13656,26 @@ function buildAutoDispatchPolicySummary(): AutoDispatchPolicySummary {
     eligibilityPreview,
   };
 }
+
+app.get("/runner-profiles", (c) => {
+  const repo = c.req.query("repo")?.trim() || null;
+  const area = (c.req.query("area")?.trim() as CompanyBrainArea | undefined) || null;
+  const riskClass = (c.req.query("riskClass")?.trim() as RiskClass | undefined) || null;
+  const profiles = RUNNER_PROFILE_REGISTRY.map((profile) => ({
+    profile,
+    evaluation: evaluateRunnerProfile({
+      profileId: profile.id,
+      repo,
+      area,
+      riskClass,
+    }),
+  }));
+  const response: ListRunnerProfilesResponse = {
+    generatedAt: now(),
+    profiles,
+  };
+  return c.json({ data: response });
+});
 
 app.get("/auto-dispatch/policy", (c) => {
   const data = buildAutoDispatchPolicySummary();
@@ -18326,15 +18609,19 @@ async function runOperatingLoopAutoDispatchTick(args: {
     };
   }
 
-  // Trigger async execution. When the auto-dispatch config carries a
-  // commandOverride (e.g., dogfood smoke with `echo`), pass it through to
-  // execute-async so the operator can validate the dispatch chain
-  // without invoking the real agent binary.
+  // Trigger async execution. Profile selection takes precedence over
+  // commandOverride; both produce execute-async commandOverride/argsOverride.
   const execBody: Record<string, unknown> = {
     actor: autoActor,
     rationale: autoRationale,
   };
-  if (eligibility.config.commandOverride) {
+  if (eligibility.config.profileId) {
+    const profile = getRunnerProfile(eligibility.config.profileId);
+    if (profile) {
+      execBody.commandOverride = profile.command;
+      execBody.argsOverride = profile.args;
+    }
+  } else if (eligibility.config.commandOverride) {
     execBody.commandOverride = eligibility.config.commandOverride;
   }
   try {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1583,6 +1583,45 @@ server.registerTool(
 );
 
 server.registerTool(
+  "list_company_brain_runner_profiles",
+  {
+    title: "List Company Brain runner profiles",
+    description:
+      "List registered runner profiles (noop-echo, dogfood-true, claude-code-real, codex-cli-real) with availability evaluation against optional repo/area/risk filters. Profiles are typed alternatives to raw command overrides.",
+    inputSchema: {
+      repo: z.string().optional(),
+      area: z
+        .enum([
+          "strategy",
+          "development",
+          "operations",
+          "product",
+          "marketing",
+          "sales",
+          "finance",
+          "people",
+          "customer",
+          "platform",
+          "unknown",
+        ])
+        .optional(),
+      riskClass: z.enum(["A", "B", "C", "unknown"]).optional(),
+    },
+  },
+  async ({ repo, area, riskClass }) => {
+    const params = new URLSearchParams();
+    if (repo) params.set("repo", repo);
+    if (area) params.set("area", area);
+    if (riskClass) params.set("riskClass", riskClass);
+    const suffix = params.toString() ? `?${params.toString()}` : "";
+    const result = await daemonFetch<{ data: unknown }>(
+      `/api/company-brain/runner-profiles${suffix}`
+    );
+    return formatJsonResult(result.data);
+  }
+);
+
+server.registerTool(
   "get_company_brain_auto_dispatch_policy",
   {
     title: "Get Company Brain Auto-Dispatch policy",

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1586,6 +1586,83 @@ export type AgentRunRunnerType =
   | "manual"
   | "other";
 
+export type RunnerProfileAuthMode =
+  | "none"
+  | "github_token"
+  | "anthropic_api_key"
+  | "openai_api_key"
+  | "shell_only";
+
+export type RunnerProfileCapability =
+  | "no_op"
+  | "shell_command"
+  | "code_edit"
+  | "git_commit"
+  | "github_pr_open"
+  | "github_pr_writeback"
+  | "github_status_check"
+  | "test_runner";
+
+export interface RunnerProfileOutputContract {
+  /** structured = expects JSON session_result on stdout; fallback = parses last lines */
+  format: "structured" | "fallback" | "noop";
+  expectedExitCodes: number[];
+  description: string;
+}
+
+export interface RunnerProfile {
+  id: string;
+  title: string;
+  description: string;
+  command: string;
+  args: string[];
+  capabilities: RunnerProfileCapability[];
+  authMode: RunnerProfileAuthMode;
+  allowedRepos: string[] | "*";
+  allowedAreas: CompanyBrainArea[] | "*";
+  maxConcurrency: number;
+  riskCeiling: RiskClass;
+  outputContract: RunnerProfileOutputContract;
+  /**
+   * Whether this profile is selectable by default (no env opt-in needed).
+   * Real coding profiles default to false; noop/dogfood profiles default
+   * to true so smoke tests can use them without extra config.
+   */
+  defaultEnabled: boolean;
+  /**
+   * Env var that toggles this profile (when defaultEnabled=false). Setting
+   * it to "true" makes the profile available to auto-dispatch and manual
+   * runs.
+   */
+  enabledEnvVar?: string;
+  /** Audit/UI label */
+  category: "noop" | "dogfood" | "real_agent";
+}
+
+export type RunnerProfileBlockReason =
+  | "profile_not_found"
+  | "profile_not_enabled"
+  | "profile_command_not_allowlisted"
+  | "profile_repo_not_allowed"
+  | "profile_area_not_allowed"
+  | "profile_risk_ceiling_exceeded";
+
+export interface RunnerProfileEvaluation {
+  profileId: string;
+  available: boolean;
+  reason: RunnerProfileBlockReason | null;
+  detail: string;
+  enabledEnvVar?: string;
+}
+
+export interface ListRunnerProfilesResponse {
+  generatedAt: number;
+  profiles: Array<{
+    profile: RunnerProfile;
+    evaluation: RunnerProfileEvaluation;
+  }>;
+}
+
 export type AutoDispatchDecision =
   | "blocked_default_off"
   | "blocked_repo"
@@ -1635,6 +1712,14 @@ export interface AutoDispatchPolicyConfig {
    * WORKFLOW.md `agent.command`.
    */
   commandOverride: string | null;
+  /**
+   * Optional runner profile id selected via
+   * AIOS_AGENT_AUTODISPATCH_PROFILE_ID. When set, auto-dispatch uses the
+   * profile's command/args (taking precedence over commandOverride and
+   * WORKFLOW.md agent.command). Eligibility additionally checks the
+   * profile is enabled and that repo/area/risk are within profile bounds.
+   */
+  profileId: string | null;
 }
 
 export interface AutoDispatchRuntimeState {


### PR DESCRIPTION
## Summary

Closes #104

AIOS-RUN-29: typed runner profile registry with explicit capabilities, auth modes, allowlists, risk ceilings and output contracts. Auto-dispatch can select an explicit profile via env var instead of relying on loose command override strings.

### Built-in profiles

| id | category | command | defaultEnabled | risk ceiling | allowed repos | capabilities |
|---|---|---|---|---|---|---|
| `noop-echo` | noop | `echo aios-noop-runner-heartbeat` | true | A | `*` | `no_op` |
| `dogfood-true` | dogfood | `true` | true | A | `*` | `no_op` |
| `claude-code-real` | real_agent | `claude -p` | **false** | B | `antonio-mello-ai/crewdock` | `shell_command, code_edit, git_commit, github_pr_open, test_runner` |
| `codex-cli-real` | real_agent | `codex` | **false** | B | `antonio-mello-ai/crewdock` | same as Claude |

Real-agent profiles are explicitly OFF by default. Each carries an `enabledEnvVar`:
- `AIOS_AGENT_RUNNER_PROFILE_CLAUDE_CODE_ENABLED=true`
- `AIOS_AGENT_RUNNER_PROFILE_CODEX_CLI_ENABLED=true`

### Evaluation gates per profile

`evaluateRunnerProfile({ profileId, repo, area, riskClass })` checks:

1. `profile_not_found` — profile id not in registry
2. `profile_not_enabled` — default-OFF and `enabledEnvVar` not set
3. `profile_command_not_allowlisted` — profile command not in `AIOS_AGENT_RUNNER_COMMAND_ALLOWLIST`
4. `profile_repo_not_allowed`
5. `profile_area_not_allowed`
6. `profile_risk_ceiling_exceeded`

### Auto-dispatch integration

- `AutoDispatchPolicyConfig.profileId` populated from `AIOS_AGENT_AUTODISPATCH_PROFILE_ID`.
- New gate `runner_profile_available` chained after the existing 11 gates.
- Chained `evaluateRunnerPolicy` receives `profile.command` as `commandOverride` so the manual policy gate accepts the typed selection.
- Dispatch tick passes `profile.command` + `profile.args` to `/execute-async` (takes precedence over `AIOS_AGENT_AUTODISPATCH_COMMAND_OVERRIDE`).

### API/MCP

- `GET /api/company-brain/runner-profiles?repo=&area=&riskClass=` lists all profiles with per-profile evaluation against the optional filters.
- MCP tool `list_company_brain_runner_profiles` wraps the endpoint.

### Test plan

- [x] `npx turbo build` clean.
- [x] Default state: `noop-echo` + `dogfood-true` available; both real profiles blocked with `reason=profile_not_enabled` and `enabledEnvVar` populated for hint chain.
- [x] With `AIOS_AGENT_RUNNER_PROFILE_CLAUDE_CODE_ENABLED=true`: profile available for matching repo/area/risk; blocked for `k2-digital/foo` (`profile_repo_not_allowed`), `area=finance` (`profile_area_not_allowed`), `risk=C` (`profile_risk_ceiling_exceeded`).
- [x] Auto-dispatch with `AIOS_AGENT_AUTODISPATCH_PROFILE_ID=noop-echo`: AgentRun status=completed, errorSummary=None.
- [ ] Production smoke after deploy.

### Constraints honored

- Real-agent profiles default-OFF.
- `claude-code-real`/`codex-cli-real` `allowedRepos` restricted to `antonio-mello-ai/crewdock`; no customer repo.
- No new secret, paid service, auto-merge, auto-deploy, broad multi-issue auto-dispatch.
- Production stays default-off for real coding profiles.

### Backward compat

- Existing `AIOS_AGENT_AUTODISPATCH_COMMAND_OVERRIDE` still works when no `profileId` is set.
- `WORKFLOW.md` `agent.command` still consumed as final fallback.
- No schema migration; profile registry lives in code only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)