### PR TITLE
feat: agentrun to github pr proposal preview v6

### DIFF
--- a/packages/daemon/src/routes/company-brain.ts
+++ b/packages/daemon/src/routes/company-brain.ts
@@ -105,6 +105,8 @@ import type {
   AgentRunReconciliationFinding,
   CollectAgentRunPatchPacketResponse,
   EvaluateAutoDispatchEligibilityRequest,
+  GitHubPrProposalPayload,
+  PreviewGitHubPrProposalResponse,
   ListAgentRunSuggestionsResponse,
   ListRunnerProfilesResponse,
   OperatingLoopAutoDispatchOutcome,
@@ -13983,6 +13985,258 @@ app.get("/agent-runs/:id/patch-packet", (c) => {
     packet,
   };
   return c.json({ data: response });
+});
+
+app.post("/agent-runs/:id/github-pr-proposal/preview", async (c) => {
+  const db = getDb();
+  const id = c.req.param("id");
+  const body = (await c.req.json().catch(() => ({}))) as {
+    actor?: string;
+    rationale?: string;
+    titleOverride?: string;
+    bodyOverride?: string;
+  };
+  const actor = body.actor?.trim();
+  if (!actor) {
+    return c.json({ error: "validation", message: "actor is required" }, 400);
+  }
+  const run = db
+    .select()
+    .from(cbAgentRuns)
+    .where(eq(cbAgentRuns.id, id))
+    .get() as typeof cbAgentRuns.$inferSelect | undefined;
+  if (!run) {
+    return c.json({ error: "not_found", message: "agent run not found" }, 404);
+  }
+  if (!run.repo) {
+    return c.json(
+      {
+        error: "validation",
+        message: "AgentRun.repo is missing; cannot build PR proposal",
+      },
+      400
+    );
+  }
+  if (!run.branch) {
+    return c.json(
+      {
+        error: "validation",
+        message: "AgentRun.branch is missing; cannot build PR proposal",
+      },
+      400
+    );
+  }
+
+  // Collect a fresh patch packet (do not persist a new artifact — reuse
+  // the most recent persisted one if it matches the current signature).
+  const packet = collectAgentRunPatchPacket({ agentRun: run });
+  if (packet.status !== "clean" && packet.status !== "dirty") {
+    return c.json(
+      {
+        error: "blocked",
+        message: `patch packet status=${packet.status}; cannot build PR proposal`,
+        data: { packet },
+      },
+      400
+    );
+  }
+  if (
+    packet.diffStat.filesChanged === 0 &&
+    packet.changedFiles.length === 0 &&
+    packet.commits.length === 0
+  ) {
+    return c.json(
+      {
+        error: "blocked",
+        message: "patch packet has no diff and no commits; nothing to propose",
+        data: { packet },
+      },
+      400
+    );
+  }
+
+  const workflow = loadWorkflowFromRepoRoot();
+  const baseBranch = packet.baseRef ?? workflow.config.workspace.baseBranch ?? "main";
+  const sourceBranch = run.branch;
+  const repo = run.repo;
+
+  // Build idempotency key from packet signature so re-running preview
+  // for the same workspace state returns the same proposal.
+  const packetSignature = createHash("sha256")
+    .update(
+      JSON.stringify({
+        agentRunId: run.id,
+        repo,
+        sourceBranch,
+        baseBranch,
+        changedFiles: packet.changedFiles,
+        commits: packet.commits.map((c) => c.sha),
+      })
+    )
+    .digest("hex");
+  const idempotencyKey = `aios-pr-proposal:${run.id}:${packetSignature.slice(0, 16)}`;
+
+  const workItem = run.workItemId
+    ? ((db
+        .select()
+        .from(cbWorkItems)
+        .where(eq(cbWorkItems.id, run.workItemId))
+        .get() as WorkItem | undefined) ?? null)
+    : null;
+
+  const titleBase =
+    body.titleOverride?.trim() ||
+    (workItem ? workItem.title : `AIOS AgentRun ${run.id} proposal`);
+  const title = `feat(aios): ${titleBase}`.slice(0, 240);
+
+  const validationsSummary = packet.validations.length
+    ? packet.validations
+        .map((v) => `${v.kind}=${v.status}`)
+        .join("; ")
+        .slice(0, 240)
+    : "(no validations recorded)";
+
+  const bodyText =
+    body.bodyOverride?.trim() ||
+    [
+      `## Summary`,
+      "",
+      workItem ? `Closes ${workItem.externalId ?? `#${workItem.id}`}.` : "",
+      "",
+      "Authored by AIOS Agent Run.",
+      "",
+      `### Patch packet`,
+      "",
+      `- agentRunId: ${run.id}`,
+      `- workItemId: ${workItem?.id ?? "-"}`,
+      `- baseRef: ${baseBranch}`,
+      `- changedFiles: ${packet.changedFiles.length} (${packet.changedFiles
+        .slice(0, 10)
+        .map((f) => `${f.status} ${f.path}`)
+        .join(", ")})`,
+      `- diffStat: ${packet.diffStat.filesChanged} files / +${packet.diffStat.insertions} / -${packet.diffStat.deletions}`,
+      `- commits: ${packet.commits.length} ahead of ${baseBranch}`,
+      "",
+      `### Validations`,
+      "",
+      validationsSummary,
+      "",
+      `### Safety`,
+      "",
+      "- AIOS-authored. Requires human review before merge.",
+      "- This is a preview proposal; no GitHub mutation has occurred.",
+    ]
+      .filter(Boolean)
+      .join("\n");
+
+  const payload: GitHubPrProposalPayload = {
+    repo,
+    sourceBranch,
+    baseBranch,
+    title,
+    body: bodyText,
+    agentRunId: run.id,
+    workItemId: run.workItemId,
+    patchPacketArtifactId: packet.artifactId,
+    patchPacketSignature: packetSignature,
+    changedFileCount: packet.changedFiles.length,
+    diffStat: packet.diffStat,
+    commitCount: packet.commits.length,
+    validationsSummary,
+    safetyMarkers: {
+      aiosAuthored: true,
+      requiresHumanReview: true,
+      dryRunOnly: true,
+    },
+  };
+
+  // Idempotency: if a proposal with this idempotencyKey exists, return it.
+  const existing = db
+    .select()
+    .from(cbExternalActionProposals)
+    .where(eq(cbExternalActionProposals.idempotencyKey, idempotencyKey))
+    .get();
+  if (existing) {
+    const response: PreviewGitHubPrProposalResponse = {
+      generatedAt: now(),
+      proposalId: existing.id,
+      alreadyExisted: true,
+      payload,
+      proposal: existing as unknown as ExternalActionProposal,
+    };
+    return c.json({ data: response });
+  }
+
+  const timestamp = now();
+  const proposalId = nanoid(12);
+  const auditEntry = {
+    at: timestamp,
+    actor,
+    event: "external_action_proposal_created" as const,
+    note: body.rationale?.trim() ?? null,
+    metadata: {
+      kind: "github_pr_create",
+      idempotencyKey,
+      patchPacketSignature: packetSignature,
+    },
+  };
+  const proposalRow: ExternalActionProposal = {
+    id: proposalId,
+    guidanceItemId: "", // PR proposals are AgentRun-driven, not Guidance-driven
+    signalId: null,
+    findingId: null,
+    workItemId: run.workItemId,
+    workflowRunId: null,
+    title,
+    rationale:
+      body.rationale?.trim() ??
+      `Preview-only PR proposal generated from AgentRun ${run.id} patch packet`,
+    destinationType: "github",
+    destinationRef: `${repo}:${sourceBranch}->${baseBranch}`,
+    actionType: "github_pr_create",
+    payload: payload as unknown as Record<string, unknown>,
+    riskClass: workItem?.riskClass ?? "B",
+    actionPolicy: "request_human",
+    policySummary:
+      "Preview-only PR proposal. No GitHub push/merge/deploy occurs from this record. Human review required before any executor runs.",
+    approvalStatus: "pending",
+    approvalRequired: true,
+    requestedBy: actor,
+    approvedBy: null,
+    approvedAt: null,
+    rejectionReason: null,
+    executionStatus: "not_started",
+    externalId: null,
+    externalUrl: null,
+    errorSummary: null,
+    rollbackRef: null,
+    idempotencyKey,
+    auditTrail: [auditEntry],
+    visibility: "internal",
+    provenance: {
+      sourceId: run.sourceId ?? "",
+      rawRef: `aios://agent-run/${run.id}`,
+      artifactId: packet.artifactId ?? undefined,
+      createdFrom: "company_brain:agent_run_pr_proposal_preview",
+      confidence: 1,
+      extractedAt: timestamp,
+      humanReviewStatus: "pending",
+      visibility: "internal",
+      notes: `signature=${packetSignature.slice(0, 12)}; agentRunId=${run.id}`,
+    },
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+  db.insert(cbExternalActionProposals).values(proposalRow as never).run();
+
+  const response: PreviewGitHubPrProposalResponse = {
+    generatedAt: timestamp,
+    proposalId,
+    alreadyExisted: false,
+    payload,
+    proposal: proposalRow,
+  };
+  return c.json({ data: response }, 201);
 });
 
 app.get("/runner-profiles", (c) => {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1583,6 +1583,32 @@ server.registerTool(
 );
 
 server.registerTool(
+  "preview_company_brain_agent_run_github_pr_proposal",
+  {
+    title: "Preview Company Brain AgentRun GitHub PR proposal",
+    description:
+      "Build a preview-only ExternalActionProposal of kind github_pr_create from a completed AgentRun's patch packet. Idempotent per packet signature. Does NOT push, open PRs, merge or deploy.",
+    inputSchema: {
+      agentRunId: z.string().min(1),
+      actor: z.string().min(1),
+      rationale: z.string().optional(),
+      titleOverride: z.string().optional(),
+      bodyOverride: z.string().optional(),
+    },
+  },
+  async ({ agentRunId, ...rest }) => {
+    const result = await daemonFetch<{ data: unknown }>(
+      `/api/company-brain/agent-runs/${agentRunId}/github-pr-proposal/preview`,
+      {
+        method: "POST",
+        body: JSON.stringify(rest),
+      }
+    );
+    return formatJsonResult(result.data);
+  }
+);
+
+server.registerTool(
   "get_company_brain_agent_run_patch_packet",
   {
     title: "Get Company Brain AgentRun patch/validation packet",

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -417,6 +417,7 @@ export type ExternalActionKind =
   | "github_status"
   | "github_check"
   | "github_issue_create"
+  | "github_pr_create"
   | "thread_reply"
   | "slack_thread_reply"
   | "draft"
@@ -1791,6 +1792,36 @@ export interface AgentRunSuggestion {
   dismissedAt: number | null;
   createdAt: number;
   updatedAt: number;
+}
+
+export interface GitHubPrProposalPayload {
+  repo: string;
+  sourceBranch: string;
+  baseBranch: string;
+  title: string;
+  body: string;
+  agentRunId: string;
+  workItemId: string | null;
+  patchPacketArtifactId: string | null;
+  patchPacketSignature: string;
+  changedFileCount: number;
+  diffStat: { filesChanged: number; insertions: number; deletions: number };
+  commitCount: number;
+  validationsSummary: string;
+  safetyMarkers: {
+    aiosAuthored: boolean;
+    requiresHumanReview: boolean;
+    dryRunOnly: boolean;
+  };
+}
+
+export interface PreviewGitHubPrProposalResponse {
+  generatedAt: number;
+  proposalId: string;
+  alreadyExisted: boolean;
+  payload: GitHubPrProposalPayload;
+  /** Inline preview of the proposal record after upsert */
+  proposal: ExternalActionProposal;
 }
 
 export type AgentRunPatchPacketStatus =


### PR DESCRIPTION
## Summary

Closes #106

AIOS-RUN-31: builds preview-only `ExternalActionProposal` of kind `github_pr_create` from a completed AgentRun's patch packet (#105), idempotent per packet signature. **No GitHub mutation occurs from preview.**

### Shared types

- `ExternalActionKind` gains `"github_pr_create"`.
- `GitHubPrProposalPayload` with `repo`, `sourceBranch`, `baseBranch`, `title`, `body`, `agentRunId`, `workItemId`, `patchPacketArtifactId`, `patchPacketSignature`, `changedFileCount`, `diffStat`, `commitCount`, `validationsSummary`, `safetyMarkers` (`aiosAuthored=true`, `requiresHumanReview=true`, `dryRunOnly=true`).
- `PreviewGitHubPrProposalResponse` returns `proposalId`, `alreadyExisted`, `payload`, `proposal`.

### Endpoint

`POST /api/company-brain/agent-runs/:id/github-pr-proposal/preview`

| Path | Behavior |
|---|---|
| Missing `actor` | 400 |
| `AgentRun.repo` or `branch` missing | 400 |
| Patch packet status `no_workspace` / `no_git` / `error` | 400 with packet payload |
| No diff and no commits | 400 |
| Existing proposal for the same signature | 200 with `alreadyExisted=true` |
| Otherwise | 201 with new proposal record |

The new `ExternalActionProposal`:

- `actionType=github_pr_create`, `destinationType=github`, `destinationRef=<repo>:<sourceBranch>-><baseBranch>`
- `approvalStatus=pending`, `approvalRequired=true`, `executionStatus=not_started`, `actionPolicy=request_human`
- `idempotencyKey = aios-pr-proposal:<runId>:<sig.slice(0,16)>` derived from sha256 over `(runId, repo, sourceBranch, baseBranch, changedFiles, commitShas)`
- `policySummary` explicitly states no GitHub mutation occurs
- Audit trail records `external_action_proposal_created` with actor + rationale + idempotency metadata

PR body template (overridable):

- `Closes <externalId>` for linked WorkItem
- AIOS-authored notice
- Patch packet summary
- Validations summary
- Safety markers

### MCP

`preview_company_brain_agent_run_github_pr_proposal`.

### Test plan

- [x] `npx turbo build` clean.
- [x] Worktree with 1 commit ahead + 1 file → preview returns `commitCount=1`, `diffStat={1, 1, 0}`, `safetyMarkers` all true, proposal `pending/not_started`.
- [x] Re-preview → same `proposalId` with `alreadyExisted=true`.
- [x] Missing `actor` → 400 validation.
- [ ] Production smoke after deploy.

### Constraints honored

- No push, no PR creation, no merge, no deploy.
- Only the proposal record is written; no external HTTP call to GitHub.
- `approvalRequired=true` so any future executor (#107) needs explicit human approval.
- Existing writeback governance, HITL rationale and audit trail reused via `cb_external_action_proposals`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)