### PR TITLE
feat: approved github pr writeback executor v6

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -107,6 +107,18 @@ Built-in profiles queryable via `GET /runner-profiles?repo=...&area=...&riskClas
 
 Real-agent profiles are explicitly OFF by default. Each carries an `enabledEnvVar` the operator must set to `true` before the profile becomes selectable. The eligibility evaluator chains the runner profile gate after all other auto-dispatch gates so policy hints stay specific.
 
+## GitHub PR writeback env vars (AIOS-RUN-32)
+
+The approved-PR executor (`POST /external-action-proposals/:id/execute-pr`) is **default-off** and requires:
+
+| Env var | Format | Notes |
+|---|---|---|
+| `AIOS_AGENT_GITHUB_PR_WRITEBACK_ENABLED` | boolean string | Master switch. Unset or anything other than `"true"` blocks all PR writeback. |
+| `AIOS_AGENT_GITHUB_PR_WRITEBACK_REPO_ALLOWLIST` | CSV of `owner/name` | Repos allowed to receive AIOS-authored PRs. Example: `antonio-mello-ai/crewdock`. |
+| `GITHUB_TOKEN` or `GH_TOKEN` | string | Existing daemon token. **No new secret introduced** — must be the same token already in use for GitHub Issues sync. |
+
+The PR body always carries an invisible `<!-- aios:proposalId=...:agentRunId=...:sig=... -->` marker so re-executing the same proposal is idempotent (the executor lists open/closed PRs filtered by `head=<owner>:<branch>` and reuses the existing one when the marker matches).
+
 ## Manual runner env vars
 
 Auto-dispatch chains `evaluateRunnerPolicy(intent=real_execution)`, so the manual runner env vars must also be set:

--- a/packages/daemon/src/routes/company-brain.ts
+++ b/packages/daemon/src/routes/company-brain.ts
@@ -105,6 +105,8 @@ import type {
   AgentRunReconciliationFinding,
   CollectAgentRunPatchPacketResponse,
   EvaluateAutoDispatchEligibilityRequest,
+  ExecuteGitHubPrProposalRequest,
+  ExecuteGitHubPrProposalResponse,
   GitHubPrProposalPayload,
   PreviewGitHubPrProposalResponse,
   ListAgentRunSuggestionsResponse,
@@ -13985,6 +13987,359 @@ app.get("/agent-runs/:id/patch-packet", (c) => {
     packet,
   };
   return c.json({ data: response });
+});
+
+function githubPrWritebackEnabled(): boolean {
+  return process.env.AIOS_AGENT_GITHUB_PR_WRITEBACK_ENABLED === "true";
+}
+
+function githubPrWritebackRepoAllowlist(): string[] {
+  return csvEnv(process.env.AIOS_AGENT_GITHUB_PR_WRITEBACK_REPO_ALLOWLIST);
+}
+
+const AIOS_PR_MARKER_PREFIX = "<!-- aios:proposalId=";
+
+function buildAiosPrMarker(args: {
+  proposalId: string;
+  agentRunId: string;
+  patchPacketSignature: string;
+}): string {
+  return `${AIOS_PR_MARKER_PREFIX}${args.proposalId}:agentRunId=${args.agentRunId}:sig=${args.patchPacketSignature.slice(0, 12)} -->`;
+}
+
+app.post("/external-action-proposals/:id/execute-pr", async (c) => {
+  const id = c.req.param("id");
+  const body = (await c.req.json().catch(() => ({}))) as ExecuteGitHubPrProposalRequest;
+  const actor = body.actor?.trim();
+  const rationale = body.rationale?.trim();
+  if (!actor) {
+    return c.json({ error: "validation", message: "actor is required" }, 400);
+  }
+  if (!rationale) {
+    return c.json(
+      { error: "validation", message: "rationale is required" },
+      400
+    );
+  }
+
+  const db = getDb();
+  const proposal = db
+    .select()
+    .from(cbExternalActionProposals)
+    .where(eq(cbExternalActionProposals.id, id))
+    .get() as ExternalActionProposal | undefined;
+  if (!proposal) {
+    return c.json(
+      { error: "not_found", message: `proposal ${id} not found` },
+      404
+    );
+  }
+  if (proposal.actionType !== "github_pr_create") {
+    return c.json(
+      {
+        error: "validation",
+        message: `proposal.actionType=${proposal.actionType}; expected github_pr_create`,
+      },
+      400
+    );
+  }
+  if (proposal.approvalStatus !== "approved") {
+    return c.json(
+      {
+        error: "blocked",
+        message: `proposal.approvalStatus=${proposal.approvalStatus}; approve via the writeback governance flow before executing`,
+      },
+      400
+    );
+  }
+
+  // Idempotency: already executed.
+  if (
+    proposal.executionStatus === "executed" &&
+    proposal.externalUrl &&
+    proposal.externalId
+  ) {
+    const response: ExecuteGitHubPrProposalResponse = {
+      generatedAt: now(),
+      proposalId: proposal.id,
+      alreadyExecuted: true,
+      prNumber: Number(proposal.externalId) || null,
+      prUrl: proposal.externalUrl,
+      pushedBranch: (
+        proposal.payload as unknown as GitHubPrProposalPayload
+      ).sourceBranch,
+      errorSummary: null,
+      proposal,
+    };
+    return c.json({ data: response });
+  }
+
+  const payload = proposal.payload as unknown as GitHubPrProposalPayload;
+  const repo = payload.repo;
+
+  if (!githubPrWritebackEnabled()) {
+    return c.json(
+      {
+        error: "blocked_default_off",
+        message:
+          "AIOS_AGENT_GITHUB_PR_WRITEBACK_ENABLED is not true; PR writeback default-off.",
+      },
+      400
+    );
+  }
+  const repoAllowlist = githubPrWritebackRepoAllowlist();
+  if (!repoAllowlist.includes(repo)) {
+    return c.json(
+      {
+        error: "blocked_repo",
+        message: `repo=${repo} not in AIOS_AGENT_GITHUB_PR_WRITEBACK_REPO_ALLOWLIST=[${repoAllowlist.join(",")}]`,
+      },
+      400
+    );
+  }
+
+  const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+  if (!token) {
+    return c.json(
+      {
+        error: "blocked",
+        message: "GITHUB_TOKEN/GH_TOKEN not configured for daemon; cannot push or open PR",
+      },
+      400
+    );
+  }
+
+  // Reload AgentRun to verify workspace still exists.
+  const run = db
+    .select()
+    .from(cbAgentRuns)
+    .where(eq(cbAgentRuns.id, payload.agentRunId))
+    .get() as typeof cbAgentRuns.$inferSelect | undefined;
+  if (!run) {
+    return c.json(
+      {
+        error: "validation",
+        message: `AgentRun ${payload.agentRunId} not found; cannot execute`,
+      },
+      400
+    );
+  }
+  const workspacePath = run.workspaceRef ?? null;
+  if (!workspacePath || !existsSync(workspacePath)) {
+    return c.json(
+      {
+        error: "validation",
+        message: `AgentRun workspace missing at ${workspacePath ?? "(null)"}; cannot push`,
+      },
+      400
+    );
+  }
+
+  // Idempotency check: PR with marker already exists?
+  const marker = buildAiosPrMarker({
+    proposalId: proposal.id,
+    agentRunId: payload.agentRunId,
+    patchPacketSignature: payload.patchPacketSignature,
+  });
+  const [owner, name] = repo.split("/");
+  let existingPr: { number: number; html_url: string; body: string | null } | null =
+    null;
+  try {
+    const list = await githubApiRequest<
+      Array<{ number: number; html_url: string; body: string | null }>
+    >(`/repos/${owner}/${name}/pulls`, {
+      params: { head: `${owner}:${payload.sourceBranch}`, state: "all" },
+      requireToken: true,
+    });
+    existingPr =
+      list.find((pr) => (pr.body ?? "").includes(marker)) ??
+      list.find((pr) => (pr.body ?? "").includes(`aios:proposalId=${proposal.id}`)) ??
+      null;
+  } catch (err) {
+    console.error("[company-brain] github pr list failed", err);
+  }
+
+  if (existingPr) {
+    const timestamp = now();
+    const audit = (proposal.auditTrail ?? []).concat([
+      {
+        at: timestamp,
+        actor,
+        event: "external_action_proposal_executed_idempotent" as const,
+        note: rationale,
+        metadata: {
+          prNumber: existingPr.number,
+          prUrl: existingPr.html_url,
+          marker,
+        },
+      },
+    ]);
+    db.update(cbExternalActionProposals)
+      .set({
+        executionStatus: "executed",
+        externalId: String(existingPr.number),
+        externalUrl: existingPr.html_url,
+        auditTrail: audit,
+        updatedAt: timestamp,
+      } as never)
+      .where(eq(cbExternalActionProposals.id, proposal.id))
+      .run();
+    const refreshed = db
+      .select()
+      .from(cbExternalActionProposals)
+      .where(eq(cbExternalActionProposals.id, proposal.id))
+      .get() as ExternalActionProposal;
+    const response: ExecuteGitHubPrProposalResponse = {
+      generatedAt: timestamp,
+      proposalId: proposal.id,
+      alreadyExecuted: true,
+      prNumber: existingPr.number,
+      prUrl: existingPr.html_url,
+      pushedBranch: payload.sourceBranch,
+      errorSummary: null,
+      proposal: refreshed,
+    };
+    return c.json({ data: response });
+  }
+
+  // Push branch via git -c extraheader.
+  const pushResult = spawnSync(
+    "git",
+    [
+      "-c",
+      `http.https://github.com/.extraheader=Authorization: Bearer ${token}`,
+      "-C",
+      workspacePath,
+      "push",
+      "origin",
+      `${payload.sourceBranch}:${payload.sourceBranch}`,
+    ],
+    { encoding: "utf-8" }
+  );
+  if (pushResult.status !== 0) {
+    const errSummary = (pushResult.stderr ?? "").trim().slice(0, 400);
+    const audit = (proposal.auditTrail ?? []).concat([
+      {
+        at: now(),
+        actor,
+        event: "external_action_proposal_execute_failed" as const,
+        note: rationale,
+        metadata: { phase: "git_push", errorSummary: errSummary },
+      },
+    ]);
+    db.update(cbExternalActionProposals)
+      .set({
+        executionStatus: "failed",
+        errorSummary: `git push failed: ${errSummary}`,
+        auditTrail: audit,
+        updatedAt: now(),
+      } as never)
+      .where(eq(cbExternalActionProposals.id, proposal.id))
+      .run();
+    return c.json(
+      {
+        error: "git_push_failed",
+        message: `git push origin ${payload.sourceBranch} failed`,
+        data: { errorSummary: errSummary },
+      },
+      500
+    );
+  }
+
+  // Create PR via GitHub API.
+  const bodyWithMarker = `${marker}\n\n${payload.body}`;
+  let prCreated: { number: number; html_url: string } | null = null;
+  let prError: string | null = null;
+  try {
+    const created = await githubApiRequest<{ number: number; html_url: string }>(
+      `/repos/${owner}/${name}/pulls`,
+      {
+        method: "POST",
+        requireToken: true,
+        body: {
+          title: payload.title,
+          body: bodyWithMarker,
+          head: payload.sourceBranch,
+          base: payload.baseBranch,
+          maintainer_can_modify: true,
+          draft: false,
+        },
+      }
+    );
+    prCreated = created;
+  } catch (err) {
+    prError = err instanceof Error ? err.message : "unknown";
+  }
+
+  const timestamp = now();
+  if (!prCreated) {
+    const audit = (proposal.auditTrail ?? []).concat([
+      {
+        at: timestamp,
+        actor,
+        event: "external_action_proposal_execute_failed" as const,
+        note: rationale,
+        metadata: { phase: "pr_create", errorSummary: prError },
+      },
+    ]);
+    db.update(cbExternalActionProposals)
+      .set({
+        executionStatus: "failed",
+        errorSummary: `gh pr create failed: ${prError ?? "unknown"}`,
+        auditTrail: audit,
+        updatedAt: timestamp,
+      } as never)
+      .where(eq(cbExternalActionProposals.id, proposal.id))
+      .run();
+    return c.json(
+      {
+        error: "pr_create_failed",
+        message: `GitHub PR creation failed`,
+        data: { errorSummary: prError },
+      },
+      500
+    );
+  }
+
+  const audit = (proposal.auditTrail ?? []).concat([
+    {
+      at: timestamp,
+      actor,
+      event: "external_action_proposal_executed" as const,
+      note: rationale,
+      metadata: {
+        prNumber: prCreated.number,
+        prUrl: prCreated.html_url,
+        marker,
+      },
+    },
+  ]);
+  db.update(cbExternalActionProposals)
+    .set({
+      executionStatus: "executed",
+      externalId: String(prCreated.number),
+      externalUrl: prCreated.html_url,
+      auditTrail: audit,
+      updatedAt: timestamp,
+    } as never)
+    .where(eq(cbExternalActionProposals.id, proposal.id))
+    .run();
+  const refreshed = db
+    .select()
+    .from(cbExternalActionProposals)
+    .where(eq(cbExternalActionProposals.id, proposal.id))
+    .get() as ExternalActionProposal;
+  const response: ExecuteGitHubPrProposalResponse = {
+    generatedAt: timestamp,
+    proposalId: proposal.id,
+    alreadyExecuted: false,
+    prNumber: prCreated.number,
+    prUrl: prCreated.html_url,
+    pushedBranch: payload.sourceBranch,
+    errorSummary: null,
+    proposal: refreshed,
+  };
+  return c.json({ data: response }, 201);
 });
 
 app.post("/agent-runs/:id/github-pr-proposal/preview", async (c) => {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1583,6 +1583,30 @@ server.registerTool(
 );
 
 server.registerTool(
+  "execute_company_brain_github_pr_proposal",
+  {
+    title: "Execute approved Company Brain GitHub PR proposal",
+    description:
+      "Push the AgentRun branch and open a GitHub PR for an APPROVED github_pr_create proposal. Idempotent: detects existing PR via AIOS marker. Default-OFF; requires AIOS_AGENT_GITHUB_PR_WRITEBACK_ENABLED + repo allowlist + GITHUB_TOKEN. No merge/deploy/auto-close.",
+    inputSchema: {
+      proposalId: z.string().min(1),
+      actor: z.string().min(1),
+      rationale: z.string().min(1),
+    },
+  },
+  async ({ proposalId, ...rest }) => {
+    const result = await daemonFetch<{ data: unknown }>(
+      `/api/company-brain/external-action-proposals/${proposalId}/execute-pr`,
+      {
+        method: "POST",
+        body: JSON.stringify(rest),
+      }
+    );
+    return formatJsonResult(result.data);
+  }
+);
+
+server.registerTool(
   "preview_company_brain_agent_run_github_pr_proposal",
   {
     title: "Preview Company Brain AgentRun GitHub PR proposal",

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1824,6 +1824,22 @@ export interface PreviewGitHubPrProposalResponse {
   proposal: ExternalActionProposal;
 }
 
+export interface ExecuteGitHubPrProposalRequest {
+  actor: string;
+  rationale: string;
+}
+
+export interface ExecuteGitHubPrProposalResponse {
+  generatedAt: number;
+  proposalId: string;
+  alreadyExecuted: boolean;
+  prNumber: number | null;
+  prUrl: string | null;
+  pushedBranch: string | null;
+  errorSummary: string | null;
+  proposal: ExternalActionProposal;
+}
+
 export type AgentRunPatchPacketStatus =
   | "clean"
   | "dirty"


### PR DESCRIPTION
## Summary

Closes #107

AIOS-RUN-32: first external write in the real-agent loop. Pushes the AgentRun branch and opens a GitHub PR for an APPROVED `github_pr_create` proposal. **Default-OFF**; tightly scoped via env opt-in + repo allowlist + idempotency via invisible AIOS marker. **No merge, deploy, label/status changes, or auto-close.**

### New env vars (default-off)

| Env var | Purpose |
|---|---|
| `AIOS_AGENT_GITHUB_PR_WRITEBACK_ENABLED=true` | Master switch |
| `AIOS_AGENT_GITHUB_PR_WRITEBACK_REPO_ALLOWLIST=<owner/name,...>` | CSV; must include payload.repo |
| `GITHUB_TOKEN` / `GH_TOKEN` | Already required by existing GitHub Issues sync — **NO new secret introduced** |

### Endpoint

`POST /external-action-proposals/:id/execute-pr` with `{ actor, rationale }`.

Validation order (each returns 4xx without external mutation):

1. Missing `actor`/`rationale` → 400
2. Proposal not found → 404
3. `actionType != github_pr_create` → 400
4. `approvalStatus != approved` → 400 (HITL gate)
5. Already executed → 200 `alreadyExecuted=true`
6. Env disabled → 400 `blocked_default_off`
7. Repo not in allowlist → 400 `blocked_repo`
8. `GITHUB_TOKEN` missing → 400
9. AgentRun/workspace missing → 400
10. Existing PR with marker → 200 `alreadyExecuted=true` (updates proposal with prNumber/url)
11. `git push origin <branch>` via `git -c http.https://github.com/.extraheader=Authorization: Bearer <token>` (token in spawn args, not on disk)
12. `POST /repos/<owner>/<name>/pulls` with body containing invisible marker `<!-- aios:proposalId=...:agentRunId=...:sig=12chars -->`
13. Update proposal: `executionStatus=executed`, `externalId=<prNumber>`, `externalUrl=<html_url>`, audit entry `external_action_proposal_executed`

### Failure modes

- git push failure → `executionStatus=failed`, `errorSummary` from stderr (truncated 400 chars), audit `phase=git_push`
- PR create failure → same shape with `phase=pr_create`

### Idempotency

The marker is the source of truth. Re-execute detects the existing PR and reuses it without pushing again. The marker embeds `proposalId + agentRunId + sig.slice(0, 12)` so a different patch packet signature produces a different marker and (intentionally) a different PR.

### MCP

`execute_company_brain_github_pr_proposal`.

### Test plan

- [x] `npx turbo build` clean.
- [x] **Pending approval** → 400 blocked.
- [x] **Approved but env disabled** → 400 `blocked_default_off`.
- [x] **Approved + env enabled but repo not in allowlist** → 400 `blocked_repo`.
- [x] **Missing actor** → 400 validation.
- [x] **Unknown proposal** → 404.
- [ ] Production happy-path smoke deferred to #108 dogfood (requires real branch + GitHub creds + workspace).

### Constraints honored

- Only runs on APPROVED proposals (HITL gate preserved).
- Repo allowlist enforced as a second layer beyond the proposal repo.
- No new secret/permission requested.
- No merge, label changes, status checks, deploy, auto-close.
- PR opens with `draft=false` and `maintainer_can_modify=true` so a human reviewer can edit before merge.
- Token passed via `-c extraheader` to git, not embedded in remote URL (won't leak via `git remote -v`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)