### PR TITLE
fix: clear stale work item blocked reason

### DIFF
--- a/packages/daemon/src/routes/company-brain.ts
+++ b/packages/daemon/src/routes/company-brain.ts
@@ -25913,6 +25913,7 @@ app.post("/adapters/github/issues/sync", async (c) => {
             ownerType: body.owner ? ("human" as const) : existing.ownerType,
             status: refreshedStatus,
             externalUrl: rawRef,
+            blockedReason: refreshedStatus === "blocked" ? existing.blockedReason : null,
             labels: ["github_issue", ...issueLabels],
             sourceId: source.id,
             artifactId: artifact.id,
@@ -25940,6 +25941,7 @@ app.post("/adapters/github/issues/sync", async (c) => {
               owner: refreshedWorkItem.owner,
               ownerType: refreshedWorkItem.ownerType,
               status: refreshedWorkItem.status,
+              blockedReason: refreshedWorkItem.blockedReason,
               externalUrl: refreshedWorkItem.externalUrl,
               labels: refreshedWorkItem.labels,
               sourceId: refreshedWorkItem.sourceId,
@@ -27320,8 +27322,8 @@ app.patch("/work-items/:id/status", async (c) => {
   };
   if (body.status === "blocked") {
     updates.blockedReason = body.blockedReason!.trim();
-  } else if (previousStatus === ("blocked" as WorkItemStatus)) {
-    updates.blockedReason = null;
+  } else {
+    updates.blockedReason = body.blockedReason?.trim() || null;
   }
   db.update(cbWorkItems)
     .set(updates as never)


### PR DESCRIPTION
## Summary
- clear `blockedReason` when GitHub issue sync refreshes a WorkItem to a non-blocked status
- make the internal WorkItem status update path clear stale blockers for non-blocked statuses

## Validation
- git diff --check
- npx turbo build --filter=@aios/shared --filter=@aios/daemon --force

## Context
After #139 closed, Company Brain correctly moved the WorkItem to `done` but retained the previous failed-run blocked reason. This keeps done work visually noisy.