### PR TITLE
docs: record telegram operating pack runner deploy

### DIFF
--- a/docs/action/aios-marketing-operating-pack-v0-2026-05-13.md
+++ b/docs/action/aios-marketing-operating-pack-v0-2026-05-13.md
@@ -251,6 +251,9 @@ Evolucao posterior em 2026-05-13:
 - Backup do script vivo apos naming canonico: `/home/claude/telegram-bot.py.bak-20260513-artifact-naming-a6a07594`.
 - Hash do script apos naming canonico: `da033bda64e4e7468e61891c4a041b3d332fde008b36c48da1aac1ddb3319c6e`.
 - Evolucao atual: a logica de briefing/promocao/feedback saiu do bot e entrou no daemon como Operating Pack Runner. O bot deve apenas encaminhar payloads e renderizar `responseText`.
+- Deploy do runner no CT165: repo `/home/claude/aios-runtime` em `main@db53f7c`, `aios-daemon.service` reiniciado e ativo.
+- Patch vivo do Telegram: `/home/claude/telegram-bot.py` agora tem hash `e2ac156065e995c9a9ec04e66acc35b8056eb17547e74b39c171f9aa9c30bf5b`; backup do script anterior em `/home/claude/telegram-bot.py.bak-20260513-operating-pack-runner-da033bda64e4e7468e61891c4a041b3d332fde008b36c48da1aac1ddb3319c6e`.
+- Smoke test sem envio real: chamada direta a `_route_aios_command("briefing marketing NR-1 para contabilidades")` retornou `Briefing de marketing (AIOS preview)` via `/api/company-brain/operating-packs/run`; chamada de DAGs retornou `AIOS preview (dryRun=true)` como fallback generico.
 
 ### MKT-02 - Telegram HITL
 

--- a/docs/action/aios-operational-agent-bot-inventory-2026-05-13.md
+++ b/docs/action/aios-operational-agent-bot-inventory-2026-05-13.md
@@ -116,6 +116,14 @@ O script atual:
 
 Risco: os bots sao uteis como canal rapido, mas hoje estao mais proximos de um terminal remoto com Claude do que de um agente governado. Isso explica por que a experiencia existia, mas nao se organizou como produto AIOS.
 
+Deploy em 2026-05-13:
+
+- daemon CT165 atualizado para `main@db53f7c` e `aios-daemon.service` ativo;
+- script vivo `/home/claude/telegram-bot.py` atualizado para hash `e2ac156065e995c9a9ec04e66acc35b8056eb17547e74b39c171f9aa9c30bf5b`;
+- backup do script anterior: `/home/claude/telegram-bot.py.bak-20260513-operating-pack-runner-da033bda64e4e7468e61891c4a041b3d332fde008b36c48da1aac1ddb3319c6e`;
+- services `claude-telegram-dev.service`, `claude-telegram-estrategista.service` e `claude-telegram-vendas-k2.service` reiniciados e ativos;
+- smoke test direto da funcao do bot confirmou briefing via Operating Pack Runner e fallback generico para DAGs.
+
 ## AIOS Company Brain - estado vivo
 
 Resumo live do daemon local:

--- a/docs/action/aios-telegram-command-layer-v0-2026-05-13.md
+++ b/docs/action/aios-telegram-command-layer-v0-2026-05-13.md
@@ -192,6 +192,7 @@ Implementacao:
 - Artifacts de feedback criados nos testes: `dBjxo7uM3YAb`, `V0moQ9W81eR7`, `5XdLZVSN26Lz`, `2cKrwOLu9g1T`.
 - Hash depois da politica de promocao de memoria: `a6a07594e72baf830e440adc1308105ac194140975796b664894ccecd81bc7fa`.
 - Evolucao atual: `marketing.nr1` foi movido para o daemon em `POST /api/company-brain/operating-packs/run`. O Telegram passa a ser gateway e cache de contexto do chat; briefing, naming semantico, promocao e feedback ficam no AIOS.
+- Deploy vivo: daemon em `main@db53f7c`; `/home/claude/telegram-bot.py` em hash `e2ac156065e995c9a9ec04e66acc35b8056eb17547e74b39c171f9aa9c30bf5b`; backup anterior em `/home/claude/telegram-bot.py.bak-20260513-operating-pack-runner-da033bda64e4e7468e61891c4a041b3d332fde008b36c48da1aac1ddb3319c6e`.
 
 Teste executado:
 


### PR DESCRIPTION
## Summary
- records CT165 daemon deploy evidence for the Company Brain Operating Pack Runner
- records the live Telegram bot hash, backup path, active services, and smoke-test result

## Validation
- docs-only change
- live CT165 smoke test already completed