### PR TITLE
Add AIOS agent routing resolver for operational skills

### DIFF
--- a/docs/action/aios-operational-agent-bot-inventory-2026-05-13.md
+++ b/docs/action/aios-operational-agent-bot-inventory-2026-05-13.md
@@ -10,7 +10,7 @@ O estado atual confirma uma inversao operacional:
 - Tres bots Telegram legados estao ativos no CT165.
 - O unico timer de negocio ativo no CT165 e `import-trading-scoring.timer`, ligado a um projeto pausado, e o servico correspondente esta falhando.
 - Os timers que ja tiveram valor operacional direto - Pulso data quality/DAGs, open source patrol/scout, self-evolve report, infra healthcheck, comment sentinel - estao desabilitados.
-- Os bots Telegram ativos ainda sao wrappers diretos de `claude -p`, nao uma camada AIOS: nao ha voice/transcription, command router, registro de artifact/signal/guidance, gates de writeback ou provenance no Company Brain.
+- Os bots Telegram ativos ainda usam `claude -p` como executor, mas o comando `/aios` ja esta migrando para Company Brain: Command Router, Operating Pack Runner e, no proximo corte, Agent Routing Resolver compartilhado.
 - Marketing e go-to-market sao hoje a frente com maior valor de curto prazo: Spa da Vida Ads esta documentado como ativo, Spa da Vida NR-1 tem playbook de outreach pronto e janela operacional curta, mas esses fluxos ainda nao estao integrados a timers, watchers, Telegram ou Company Brain.
 
 Conclusao pratica: o AIOS robusto deve continuar sendo a fonte de verdade, mas o proximo valor vem de transformar as automacoes existentes em "Operating Packs" pequenos, com Telegram como canal e Company Brain como registro/auditoria. O primeiro pack recomendado e Marketing/Spa da Vida NR-1, antes de reativar automacoes menos urgentes.
@@ -109,7 +109,7 @@ O script atual:
 - devolve uma previa editando a mensagem "Processando...";
 - chama o Company Brain Command Router ou o Operating Pack Runner apenas no comando `/aios`;
 - para pedidos de briefing de marketing/NR-1, deve chamar o pack `marketing.nr1` no daemon e renderizar `responseText`;
-- quando nao ha pack reconhecido e o router nao marca Risk C, encaminha o pedido para o agente/Claude CLI no `CLAUDE_CWD` do service atual;
+- quando nao ha pack reconhecido e o router nao marca Risk C, deve chamar `POST /api/company-brain/agent-routing/resolve` e encaminhar para o agente/Claude CLI usando o cwd e prompt resolvidos pelo AIOS;
 - nao registra briefing sob demanda como artifact por default; usa `/aios promover briefing [motivo]` para promover memoria estrategica;
 - aceita feedback HITL para briefing de marketing via `/aios feedback ...` somente quando houver artifact promovido ou `artifactId` explicito, registrando artifact `marketing_feedback` e atualizando a guidance de marketing;
 - fora do briefing de marketing, ainda nao cria `Signal`, `GuidanceItem`, `WorkItem`, `AgentRun` ou `ExternalActionProposal` automaticamente;
@@ -141,6 +141,13 @@ Correcao de cwd posterior em 2026-05-13:
 - hash do script vivo: `da969e142800b2759b067c2f842a8c2d5186bd8dc93e6c04987e20d2fb93897e`;
 - backup anterior: `/home/claude/telegram-bot.py.bak-20260513-routed-cwd-f817fa33d822bdd4c0f53bb0770f1d9bb889bb9cfade5e050563ed6c2ae1cbfb`;
 - teste sem executar Claude real: DAGs/Pulso resolveu o fallback para `pulsoonline-backend`, marketing continuou no pack e Risk C continuou preview-only.
+
+Evolucao atual deste corte:
+
+- a skill AIOS `operations.pulso_dags` foi documentada em `docs/action/aios-operations-pulso-dags-pack-v0-2026-05-13.md`;
+- o daemon passa a resolver skill, cwd e prompt em `POST /api/company-brain/agent-routing/resolve`;
+- o MCP tambem expoe `resolve_company_brain_agent_route`, para que Codex/outros agentes usem a mesma decisao do Telegram;
+- o bot deve parar de manter roteamento hardcoded por keywords locais e consumir o resolver do AIOS.
 
 ## AIOS Company Brain - estado vivo
 

--- a/docs/action/aios-operations-pulso-dags-pack-v0-2026-05-13.md
+++ b/docs/action/aios-operations-pulso-dags-pack-v0-2026-05-13.md
@@ -1,0 +1,94 @@
+# AIOS Operations Pack v0 - Pulso DAGs
+
+Este documento define a skill operacional `operations.pulso_dags`. Ela vive no AIOS Runtime e deve ser consumida por qualquer canal ou agente: Telegram, MCP/Codex, schedule futuro ou UI. Telegram e apenas transporte.
+
+## Objetivo
+
+Responder pedidos como:
+
+- "olha as DAGs do Pulso"
+- "verifica se as DAGs rodaram"
+- "teve problema no Airflow?"
+- "as tabelas foram preenchidas?"
+- "tem pipeline de dados com erro?"
+
+O resultado esperado e um relatorio operacional curto, read-only primeiro, com evidencias, impacto e proximas acoes. A skill nao deve virar artifact por padrao.
+
+## Onde executar
+
+Workspace default:
+
+```text
+/mnt/felhencloud/projetos/marketplace_data_intelligence/pulsoonline-backend
+```
+
+Fontes locais esperadas:
+
+- `AGENTS.md`
+- `.claude/skills/dag-check.md`
+- `docs/architecture/etl-flow.md`
+- `apps/dags/*.py`
+
+O runtime resolve esse workspace em `POST /api/company-brain/agent-routing/resolve`. Clientes nao devem manter roteamento hardcoded por canal.
+
+## Regras obrigatorias
+
+1. Comecar read-only.
+2. Ler `AGENTS.md` e `.claude/skills/dag-check.md` quando existirem.
+3. Usar hostnames do SSH config, nao IP direto.
+4. Consultar metadados do Airflow no PostgreSQL quando necessario; em historico Pulso isso foi mais confiavel que apenas CLI.
+5. Separar status de execucao, erro estrutural, frescor/volume de tabelas e impacto no cliente.
+6. Categorias de DAGs ativas devem ser mutuamente exclusivas: rodaram ok, falharam, fora do schedule, anomalia.
+7. Se uma DAG falhou e depois teve rerun com sucesso, reportar como ruido historico salvo se houver impacto restante.
+8. Nao executar restart, rerun, retry, unpause, backfill, deploy ou alteracao em servico sem pedido explicito do usuario.
+9. Se houver acao corretiva recomendada, listar como HITL: `acao sugerida`, `risco`, `comando aproximado` quando seguro.
+10. Resposta para Telegram deve ficar abaixo de 4000 caracteres quando possivel.
+
+## Formato de resposta
+
+```text
+DAGs Pulso - status de hoje
+Estado: verde|atencao|incidente
+
+Resumo:
+- X rodaram ok
+- Y falharam
+- Z fora do schedule
+- W anomalias
+
+Evidencia:
+- ...
+
+Impacto:
+- ...
+
+Proxima acao:
+- ...
+
+HITL:
+- nada executado / confirmar antes de rerun / confirmar antes de restart
+```
+
+## Politica de memoria
+
+Nao criar Artifact para cada briefing operacional.
+
+Persistir no Company Brain somente quando houver:
+
+- incidente real ou degradacao com evidencia;
+- falha repetida que deva virar guidance, watcher ou work item;
+- decisao operacional reutilizavel;
+- aprendizado estrategico para produto/processo;
+- promocao explicita pelo humano.
+
+Saida verde ou investigacao pontual sem aprendizado novo deve ser efemera.
+
+## Encaixe com Cofounder / areas
+
+Esta skill pertence a `Operations`, mas pode ser invocada a partir de qualquer canal. O fluxo correto e:
+
+```text
+mensagem -> AIOS Command Router -> agent-routing/resolve -> skill operations.pulso_dags -> agente no workspace Pulso
+```
+
+Assim a regra fica compartilhada entre agentes e nao presa ao bot Telegram.

--- a/docs/action/aios-telegram-command-layer-v0-2026-05-13.md
+++ b/docs/action/aios-telegram-command-layer-v0-2026-05-13.md
@@ -37,6 +37,7 @@ Telegram bot = canal
 AIOS Command Router = despacho
 Area Blueprint Registry = departamentos
 Operating Pack = rotina por area
+Agent Routing Resolver = skill/cwd/prompt compartilhado entre canais
 Agent/Claude CLI = executor quando necessario
 Company Brain = memoria/evidencia/auditoria
 ```
@@ -52,7 +53,7 @@ Adicionar um modo incremental:
 | Legado | mensagem normal | Continua rodando `claude -p` como hoje |
 | AIOS preview | comando `/aios <texto>` | Chama `POST /api/company-brain/command-router` com `dryRun=true` |
 | AIOS operating pack | comando `/aios <texto>` quando houver pack reconhecido | Chama `POST /api/company-brain/operating-packs/run` e devolve `responseText` |
-| AIOS agent fallback | `/aios <texto>` sem pack reconhecido e sem Risk C | Encaminha para o agente/Claude CLI no cwd escolhido pelo roteamento; DAGs/Pulso vao para `pulsoonline-backend` |
+| AIOS agent fallback | `/aios <texto>` sem pack reconhecido e sem Risk C | Chama `POST /api/company-brain/agent-routing/resolve` e encaminha para o agente/Claude CLI no cwd/prompt retornado pelo AIOS |
 | AIOS commit Risk A | prefixo `/aios commit` | Chama command router com `dryRun=false` apenas para intents Risk A |
 | Risk C / blocked | router classifica Risk C | Bot responde com preview/bloqueio e nao executa mutacao |
 
@@ -68,7 +69,7 @@ Estas sao as interacoes que devem funcionar primeiro, sem automacao externa:
 | "o que a gente faz hoje para NR-1?" | estrategista | marketing | foco diario + 10-20 proximas acoes + draft |
 | "cria um post para a Thais sobre NR-1" | estrategista | marketing | artifact/draft + guidance para revisao |
 | "tem algum repo ou PR com problema?" | dev | development | resumo de GitHub PR/CI watcher + guidance |
-| "olha as DAGs do Pulso" | dev | operations | cai no agente executor em `pulsoonline-backend`; pack/watchers de DAGs vem depois |
+| "olha as DAGs do Pulso" | qualquer canal | operations | usa skill AIOS `operations.pulso_dags` e agente executor em `pulsoonline-backend` |
 | "o servidor caiu?" | dev | platform/operations | cai no agente executor com investigacao read-only; pack de infra vem depois |
 | "quais proximos passos do PulsoOnline?" | dev ou estrategista | product/operations | responde a partir de Company Brain/QMD e cria guidance se necessario |
 
@@ -165,7 +166,7 @@ Adicionar handlers pequenos que nao reinventam agente:
 Aceite:
 
 - Antonio consegue receber uma resposta util pelo Telegram sem abrir Codex.
-- Todo output persistente vira Artifact/Guidance.
+- Output operacional e efemero por padrao; so vira Artifact/Guidance quando houver aprendizado estrategico, incidente, decisao reutilizavel ou promocao explicita.
 
 Status em 2026-05-13: primeiro handler concluido live no CT165.
 
@@ -198,6 +199,7 @@ Implementacao:
 - Hash apos fallback para agente: `f817fa33d822bdd4c0f53bb0770f1d9bb889bb9cfade5e050563ed6c2ae1cbfb`; backup anterior em `/home/claude/telegram-bot.py.bak-20260513-agent-fallback-e2ac156065e995c9a9ec04e66acc35b8056eb17547e74b39c171f9aa9c30bf5b`.
 - Correcao de cwd aplicada depois: fallback escolhe diretorio por roteamento. DAGs/Pulso usam `/mnt/felhencloud/projetos/marketplace_data_intelligence/pulsoonline-backend`; operations/development/product usam `/mnt/felhencloud/projetos`; marketing usa `/mnt/felhencloud/projetos/marketing`; strategy usa `/mnt/felhencloud/corp`; platform usa `/home/claude/aios-runtime`.
 - Hash apos roteamento de cwd: `da969e142800b2759b067c2f842a8c2d5186bd8dc93e6c04987e20d2fb93897e`; backup anterior em `/home/claude/telegram-bot.py.bak-20260513-routed-cwd-f817fa33d822bdd4c0f53bb0770f1d9bb889bb9cfade5e050563ed6c2ae1cbfb`.
+- Evolucao atual: roteamento de fallback saiu do bot e entrou no daemon em `POST /api/company-brain/agent-routing/resolve`. A skill `operations.pulso_dags` agora e resolvida no AIOS com cwd, prompt e politica de memoria compartilhados entre Telegram e MCP/Codex.
 
 Teste executado:
 

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -96,6 +96,17 @@ export const config = {
       "production:company-brain-operating-loop"
     ),
   },
+
+  companyBrainAgentRouting: {
+    pulsoBackendCwd: env(
+      "AIOS_AGENT_ROUTE_PULSO_BACKEND_CWD",
+      "/mnt/felhencloud/projetos/marketplace_data_intelligence/pulsoonline-backend"
+    ),
+    projectsCwd: env("AIOS_AGENT_ROUTE_PROJECTS_CWD", "/mnt/felhencloud/projetos"),
+    marketingCwd: env("AIOS_AGENT_ROUTE_MARKETING_CWD", "/mnt/felhencloud/projetos/marketing"),
+    corpCwd: env("AIOS_AGENT_ROUTE_CORP_CWD", "/mnt/felhencloud/corp"),
+    runtimeCwd: env("AIOS_AGENT_ROUTE_RUNTIME_CWD", "/home/claude/aios-runtime"),
+  },
 } as const;
 
 // Fail-fast validation: refuse to boot with unsafe config in production.

--- a/packages/daemon/src/routes/company-brain.ts
+++ b/packages/daemon/src/routes/company-brain.ts
@@ -161,12 +161,15 @@ import type {
   CommandRouterRouting,
   CommandRouterTargetKind,
   RouteCompanyBrainCommandRequest,
+  CompanyBrainAgentRouteResponse,
   CompanyBrainOperatingPackAction,
   CompanyBrainOperatingPackArtifactRef,
   CompanyBrainOperatingPackMemoryPolicy,
   CompanyBrainOperatingPackRunResponse,
   CompanyBrainOperatingPackSlug,
+  CompanyBrainOperationalSkillRef,
   RunCompanyBrainOperatingPackRequest,
+  ResolveCompanyBrainAgentRouteRequest,
   GuidanceItem,
   Signal,
   CompanyBrainOperatingCadence,
@@ -23596,6 +23599,245 @@ app.post("/operating-packs/run", async (c) => {
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";
     return c.json({ error: "operating_pack_run_failed", message }, 400);
+  }
+});
+
+const PULSO_DAGS_SKILL_DOCS_PATH =
+  "docs/action/aios-operations-pulso-dags-pack-v0-2026-05-13.md";
+
+const PULSO_DAGS_SKILL: CompanyBrainOperationalSkillRef = {
+  slug: "operations.pulso_dags",
+  title: "PulsoOnline DAG health check",
+  area: "operations",
+  docsPath: PULSO_DAGS_SKILL_DOCS_PATH,
+  summary:
+    "Read-only Airflow DAG health triage for PulsoOnline: classify scheduled runs, structural failures, output freshness and next HITL actions.",
+  memoryPolicy: "ephemeral",
+};
+
+function shouldRouteToPulsoDagsSkill(text: string): boolean {
+  const normalized = normalizeOperatingPackMatchText(text);
+  return (
+    /\b(?:dag|dags|deg|degs|airflow|etl|pipeline|pipelines|job|jobs)\b/.test(normalized) ||
+    /dag_run|data quality|qualidade de dados|raw to silver|raw\/silver|mysql raw|clickhouse/.test(normalized)
+  );
+}
+
+function buildAgentRouteRouterResult(
+  request: ResolveCompanyBrainAgentRouteRequest,
+  timestamp: number,
+  preliminarySkill: CompanyBrainOperationalSkillRef | null
+): CompanyBrainCommandRouterResult {
+  const routerRequest: RouteCompanyBrainCommandRequest = {
+    text: request.text,
+    area: request.area ?? preliminarySkill?.area,
+    actor: request.actor ?? null,
+    visibility: request.visibility ?? "internal",
+    dryRun: true,
+  };
+  const classification = buildCommandRouterClassification(routerRequest);
+  const routing = executeCommandRouterClassification(routerRequest, classification, timestamp);
+  return {
+    generatedAt: timestamp,
+    request: routerRequest,
+    classification,
+    routing,
+  };
+}
+
+function resolveAgentRouteSkill(
+  request: ResolveCompanyBrainAgentRouteRequest,
+  router: CompanyBrainCommandRouterResult
+): CompanyBrainOperationalSkillRef | null {
+  if (shouldRouteToPulsoDagsSkill(request.text)) return PULSO_DAGS_SKILL;
+  if (
+    router.classification.area === "operations" &&
+    /pulso|airflow|dag|pipeline|data quality/i.test(request.text)
+  ) {
+    return PULSO_DAGS_SKILL;
+  }
+  return null;
+}
+
+function resolveAgentRouteCwd(
+  router: CompanyBrainCommandRouterResult,
+  skill: CompanyBrainOperationalSkillRef | null
+): string {
+  if (skill?.slug === "operations.pulso_dags") {
+    return config.companyBrainAgentRouting.pulsoBackendCwd;
+  }
+
+  switch (router.classification.area) {
+    case "marketing":
+      return config.companyBrainAgentRouting.marketingCwd;
+    case "strategy":
+    case "sales":
+    case "finance":
+    case "people":
+      return config.companyBrainAgentRouting.corpCwd;
+    case "platform":
+      return config.companyBrainAgentRouting.runtimeCwd;
+    case "development":
+    case "operations":
+    case "product":
+    case "customer":
+    case "unknown":
+    default:
+      return config.companyBrainAgentRouting.projectsCwd;
+  }
+}
+
+function buildAgentRoutePrompt(args: {
+  request: ResolveCompanyBrainAgentRouteRequest;
+  router: CompanyBrainCommandRouterResult;
+  skill: CompanyBrainOperationalSkillRef | null;
+  executionCwd: string;
+}): string {
+  const { request, router, skill, executionCwd } = args;
+  const header = [
+    "AIOS routed agent request",
+    `Channel: ${request.channel ?? "unknown"}`,
+    `Actor: ${request.actor ?? "unknown"}`,
+    `Area: ${router.classification.area}`,
+    `Intent: ${router.classification.intentKind}`,
+    `Risk: ${router.classification.riskClass}`,
+    `Execution cwd: ${executionCwd}`,
+  ];
+
+  const commonRules = [
+    "AIOS rules:",
+    "1. Treat this as an AIOS-governed request regardless of the channel that delivered it.",
+    "2. Read local AGENTS.md and relevant docs/skills before acting when the checkout has them.",
+    "3. Start read-only. Do not perform external sends, destructive actions, deploys, restarts, reruns, retries, unpauses or writes unless the user explicitly asked for that action and HITL is clear.",
+    "4. Keep temporary operational output ephemeral. Persist to Company Brain only for strategic learning, incident evidence, repeated failure, accepted guidance or explicit user promotion.",
+    "5. Return a concise operational answer with evidence, impact, recommended next action and any HITL needed.",
+  ];
+
+  const skillRules =
+    skill?.slug === "operations.pulso_dags"
+      ? [
+          "",
+          "Operational skill: operations.pulso_dags",
+          `Skill docs: ${skill.docsPath}`,
+          "Pulso local skill to reuse when present: .claude/skills/dag-check.md",
+          "Pulso DAG rules:",
+          "1. Verify scheduled DAG health using the Pulso checkout context, Airflow metadata/API and docs/architecture/etl-flow.md.",
+          "2. Separate execution status, structural timeout/error, output freshness/volume and customer impact.",
+          "3. Classify active DAGs into mutually exclusive categories: ran ok, failed, outside schedule, anomaly. Do not report generic success ratios that include DAGs outside today's schedule.",
+          "4. If failures have later successful reruns, report them as historical noise unless there is remaining business impact.",
+          "5. List corrective actions only. Do not rerun, restart, unpause or backfill unless the user explicitly asks.",
+          "6. Keep the Telegram answer under 4000 characters when possible.",
+        ]
+      : [];
+
+  return [
+    ...header,
+    "",
+    ...commonRules,
+    ...skillRules,
+    "",
+    "Original request:",
+    request.text.trim(),
+  ].join("\n");
+}
+
+function buildAgentRouteResponse(args: {
+  timestamp: number;
+  request: ResolveCompanyBrainAgentRouteRequest;
+  router: CompanyBrainCommandRouterResult;
+  skill: CompanyBrainOperationalSkillRef | null;
+  executionCwd: string;
+}): CompanyBrainAgentRouteResponse {
+  const { timestamp, request, router, skill, executionCwd } = args;
+  const cwdExists = existsSync(executionCwd);
+  const rationale = [
+    `Router classified area=${router.classification.area}, intent=${router.classification.intentKind}, target=${router.classification.targetKind}, risk=${router.classification.riskClass}.`,
+    skill
+      ? `Matched operational skill ${skill.slug}; channel is only transport.`
+      : "No operational skill matched; routing to area default executor.",
+    cwdExists
+      ? `Execution cwd exists: ${executionCwd}.`
+      : `Execution cwd configured but not present from daemon host view: ${executionCwd}.`,
+  ];
+
+  if (router.classification.riskClass === "C") {
+    return {
+      generatedAt: timestamp,
+      request,
+      router,
+      executionMode: "blocked",
+      decision: "blocked",
+      executionCwd: null,
+      skill,
+      prompt: null,
+      responseText: formatCommandRouterPreview(router),
+      noExternalAction: true,
+      rationale: [
+        ...rationale,
+        "Risk C is blocked before any agent fallback.",
+      ],
+    };
+  }
+
+  const prompt = buildAgentRoutePrompt({
+    request,
+    router,
+    skill,
+    executionCwd,
+  });
+
+  return {
+    generatedAt: timestamp,
+    request,
+    router,
+    executionMode: "agent_fallback",
+    decision: "route_to_agent",
+    executionCwd,
+    skill,
+    prompt,
+    responseText: [
+      "AIOS agent route",
+      skill ? `Skill: ${skill.slug}` : `Area: ${router.classification.area}`,
+      `Executor cwd: ${executionCwd}`,
+      `Risk: ${router.classification.riskClass} | confianca: ${router.classification.confidence.toFixed(2)}`,
+      "Politica: canal e transporte; skill e regras vivem no AIOS.",
+      "HITL: nenhuma acao externa foi executada pelo router.",
+    ].join("\n"),
+    noExternalAction: true,
+    rationale,
+  };
+}
+
+app.post("/agent-routing/resolve", async (c) => {
+  try {
+    const body = (await c.req
+      .json<ResolveCompanyBrainAgentRouteRequest>()
+      .catch(() => ({ text: "" } as ResolveCompanyBrainAgentRouteRequest))) as ResolveCompanyBrainAgentRouteRequest;
+    if (!body.text || !body.text.trim()) {
+      return c.json({ error: "validation", message: "text is required" }, 400);
+    }
+
+    const timestamp = now();
+    const request: ResolveCompanyBrainAgentRouteRequest = {
+      ...body,
+      text: body.text.trim(),
+      visibility: body.visibility ?? "internal",
+    };
+    const preliminarySkill = shouldRouteToPulsoDagsSkill(request.text) ? PULSO_DAGS_SKILL : null;
+    const router = buildAgentRouteRouterResult(request, timestamp, preliminarySkill);
+    const skill = resolveAgentRouteSkill(request, router);
+    const executionCwd = resolveAgentRouteCwd(router, skill);
+    const result = buildAgentRouteResponse({
+      timestamp,
+      request,
+      router,
+      skill,
+      executionCwd,
+    });
+    return c.json({ data: result });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return c.json({ error: "agent_route_resolve_failed", message }, 400);
   }
 });
 

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -2606,6 +2606,47 @@ server.registerTool(
 );
 
 server.registerTool(
+  "resolve_company_brain_agent_route",
+  {
+    title: "Resolve Company Brain agent route",
+    description:
+      "Resolve a natural-language request into an AIOS-governed agent fallback route shared by Telegram and MCP clients. Returns the command-router classification, matched operational skill when available, execution cwd, generated prompt, no-external-action policy and rationale. Risk C requests are blocked before any agent fallback.",
+    inputSchema: {
+      text: z.string().min(1),
+      actor: z.string().optional(),
+      channel: z.string().optional(),
+      sourceId: z.string().optional(),
+      area: z
+        .enum([
+          "strategy",
+          "development",
+          "operations",
+          "product",
+          "marketing",
+          "sales",
+          "finance",
+          "people",
+          "customer",
+          "platform",
+          "unknown",
+        ])
+        .optional(),
+      visibility: z.enum(["public", "internal", "restricted"]).optional(),
+    },
+  },
+  async (params) => {
+    const result = await daemonFetch<{ data: unknown }>(
+      "/api/company-brain/agent-routing/resolve",
+      {
+        method: "POST",
+        body: JSON.stringify(params),
+      }
+    );
+    return formatJsonResult(result.data);
+  }
+);
+
+server.registerTool(
   "get_company_brain_workflow_definition",
   {
     title: "Get Company Brain workflow definition",

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -4279,6 +4279,44 @@ export interface CompanyBrainOperatingPackRunResponse {
   suggestedCommands?: string[];
 }
 
+export type CompanyBrainOperationalSkillSlug = "operations.pulso_dags";
+export type CompanyBrainAgentRouteExecutionMode =
+  | "agent_fallback"
+  | "blocked"
+  | "preview_only";
+
+export interface ResolveCompanyBrainAgentRouteRequest {
+  text: string;
+  actor?: string | null;
+  channel?: string | null;
+  sourceId?: string | null;
+  area?: CompanyBrainArea;
+  visibility?: Visibility;
+}
+
+export interface CompanyBrainOperationalSkillRef {
+  slug: CompanyBrainOperationalSkillSlug;
+  title: string;
+  area: CompanyBrainArea;
+  docsPath: string;
+  summary: string;
+  memoryPolicy: CompanyBrainOperatingPackMemoryPolicy;
+}
+
+export interface CompanyBrainAgentRouteResponse {
+  generatedAt: number;
+  request: ResolveCompanyBrainAgentRouteRequest;
+  router: CompanyBrainCommandRouterResult;
+  executionMode: CompanyBrainAgentRouteExecutionMode;
+  decision: "route_to_agent" | "blocked" | "preview_only";
+  executionCwd?: string | null;
+  skill?: CompanyBrainOperationalSkillRef | null;
+  prompt?: string | null;
+  responseText: string;
+  noExternalAction: boolean;
+  rationale: string[];
+}
+
 export type CompanyOperatingMapAreaSlug =
   | "strategy"
   | "development"


### PR DESCRIPTION
## Summary
- add a shared Company Brain agent-routing resolver that returns skill, cwd, prompt, and Risk C blocking policy
- document the AIOS-wide operations.pulso_dags skill and memory policy
- expose the same resolver through the MCP server so Telegram is only one channel

## Validation
- npx turbo build --filter=@aios/shared --filter=@aios/daemon --filter=@aios/mcp-server --force
- local app.request smoke tests for DAGs, DEGs, and Risk C blocking