### PR TITLE
Document Telegram DAG auto-route

### DIFF
--- a/docs/action/aios-operational-agent-bot-inventory-2026-05-13.md
+++ b/docs/action/aios-operational-agent-bot-inventory-2026-05-13.md
@@ -113,7 +113,7 @@ O script atual:
 - nao registra briefing sob demanda como artifact por default; usa `/aios promover briefing [motivo]` para promover memoria estrategica;
 - aceita feedback HITL para briefing de marketing via `/aios feedback ...` somente quando houver artifact promovido ou `artifactId` explicito, registrando artifact `marketing_feedback` e atualizando a guidance de marketing;
 - fora do briefing de marketing, ainda nao cria `Signal`, `GuidanceItem`, `WorkItem`, `AgentRun` ou `ExternalActionProposal` automaticamente;
-- mensagens normais ainda nao aplicam gates de risco do AIOS antes de executar `claude -p`.
+- mensagens normais continuam no legado por padrao, mas pedidos claramente operacionais de DAG/Airflow/DEG ja sao auto-roteados para o pipeline AIOS antes de executar `claude -p`.
 
 Risco: os bots sao uteis como canal rapido, mas hoje estao mais proximos de um terminal remoto com Claude do que de um agente governado. Isso explica por que a experiencia existia, mas nao se organizou como produto AIOS.
 
@@ -148,6 +148,12 @@ Evolucao atual deste corte:
 - o daemon passa a resolver skill, cwd e prompt em `POST /api/company-brain/agent-routing/resolve`;
 - o MCP tambem expoe `resolve_company_brain_agent_route`, para que Codex/outros agentes usem a mesma decisao do Telegram;
 - o bot deve parar de manter roteamento hardcoded por keywords locais e consumir o resolver do AIOS.
+
+Correcao posterior deste corte:
+
+- uma mensagem normal como `As DAGs de hoje rodaram ok?` no bot estrategista nao deve mais cair no contexto legado `corp`;
+- o gateway detecta sinais claros de DAG/Airflow/DEG, chama o pipeline AIOS e recebe `operations.pulso_dags` + `pulsoonline-backend` do daemon;
+- a deteccao local e apenas um gatilho de entrada; skill, cwd, prompt e bloqueio de risco continuam resolvidos pelo AIOS.
 
 ## AIOS Company Brain - estado vivo
 

--- a/docs/action/aios-telegram-command-layer-v0-2026-05-13.md
+++ b/docs/action/aios-telegram-command-layer-v0-2026-05-13.md
@@ -51,6 +51,7 @@ Adicionar um modo incremental:
 | Modo | Como aciona | Comportamento |
 | --- | --- | --- |
 | Legado | mensagem normal | Continua rodando `claude -p` como hoje |
+| AIOS auto-route operacional | mensagem normal com sinais claros de DAG/Airflow/DEG | Chama o mesmo pipeline AIOS do `/aios` e usa `agent-routing/resolve` |
 | AIOS preview | comando `/aios <texto>` | Chama `POST /api/company-brain/command-router` com `dryRun=true` |
 | AIOS operating pack | comando `/aios <texto>` quando houver pack reconhecido | Chama `POST /api/company-brain/operating-packs/run` e devolve `responseText` |
 | AIOS agent fallback | `/aios <texto>` sem pack reconhecido e sem Risk C | Chama `POST /api/company-brain/agent-routing/resolve` e encaminha para o agente/Claude CLI no cwd/prompt retornado pelo AIOS |
@@ -200,6 +201,7 @@ Implementacao:
 - Correcao de cwd aplicada depois: fallback escolhe diretorio por roteamento. DAGs/Pulso usam `/mnt/felhencloud/projetos/marketplace_data_intelligence/pulsoonline-backend`; operations/development/product usam `/mnt/felhencloud/projetos`; marketing usa `/mnt/felhencloud/projetos/marketing`; strategy usa `/mnt/felhencloud/corp`; platform usa `/home/claude/aios-runtime`.
 - Hash apos roteamento de cwd: `da969e142800b2759b067c2f842a8c2d5186bd8dc93e6c04987e20d2fb93897e`; backup anterior em `/home/claude/telegram-bot.py.bak-20260513-routed-cwd-f817fa33d822bdd4c0f53bb0770f1d9bb889bb9cfade5e050563ed6c2ae1cbfb`.
 - Evolucao atual: roteamento de fallback saiu do bot e entrou no daemon em `POST /api/company-brain/agent-routing/resolve`. A skill `operations.pulso_dags` agora e resolvida no AIOS com cwd, prompt e politica de memoria compartilhados entre Telegram e MCP/Codex.
+- Correcao posterior: mensagens normais que mencionam claramente DAGs/Airflow/DEG agora tambem entram no pipeline AIOS. Isso evita que o bot estrategista rode no cwd `corp` e responda que nao sabe onde procurar.
 
 Teste executado:
 


### PR DESCRIPTION
## Summary
- document that normal Telegram messages with clear DAG/Airflow/DEG signals now enter the AIOS pipeline
- record that skill/cwd/prompt remain resolved by the daemon resolver, not by the channel

## Validation
- live CT165 patch py_compile
- monkeypatched bot smoke: 'As DAGs de hoje rodaram ok?' auto-routes to operations.pulso_dags in pulsoonline-backend
- Telegram services restarted and active