### PR TITLE
Point Pulso DAG skill to GCP Airflow

### DIFF
--- a/docs/action/aios-operations-pulso-dags-pack-v0-2026-05-13.md
+++ b/docs/action/aios-operations-pulso-dags-pack-v0-2026-05-13.md
@@ -27,22 +27,68 @@ Fontes locais esperadas:
 - `AGENTS.md`
 - `.claude/skills/dag-check.md`
 - `docs/architecture/etl-flow.md`
+- `docs/operations/monitoring.md`
+- `docs/operations/ssh-connections.md`
 - `apps/dags/*.py`
 
 O runtime resolve esse workspace em `POST /api/company-brain/agent-routing/resolve`. Clientes nao devem manter roteamento hardcoded por canal.
 
+## Fonte de verdade atual
+
+O Airflow produtivo atual roda na GCP:
+
+```text
+project: felhen-pulso-live-prod
+zone: southamerica-east1-b
+host: pulso-live-airflow
+```
+
+VM200, `airflow-200` e metastore `postgres-201` sao contexto legado/rollback frio. Nao usar esses hosts para responder status atual de DAGs. Se alguma skill/doc local ainda apontar para VM200 como producao, tratar como contexto desatualizado e preferir `docs/operations/monitoring.md`, `docs/operations/ssh-connections.md` e o runtime GCP.
+
 ## Regras obrigatorias
 
 1. Comecar read-only.
-2. Ler `AGENTS.md` e `.claude/skills/dag-check.md` quando existirem.
-3. Usar hostnames do SSH config, nao IP direto.
-4. Consultar metadados do Airflow no PostgreSQL quando necessario; em historico Pulso isso foi mais confiavel que apenas CLI.
+2. Ler `AGENTS.md`, `docs/operations/monitoring.md`, `docs/operations/ssh-connections.md` e `.claude/skills/dag-check.md` quando existirem.
+3. Usar `gcloud compute ssh pulso-live-airflow --project=felhen-pulso-live-prod --zone=southamerica-east1-b --tunnel-through-iap` para Airflow live quando acesso direto por Tailscale nao estiver previamente configurado.
+4. Consultar metadados do Airflow dentro do container GCP quando necessario; em historico Pulso isso foi mais confiavel que apenas CLI.
 5. Separar status de execucao, erro estrutural, frescor/volume de tabelas e impacto no cliente.
 6. Categorias de DAGs ativas devem ser mutuamente exclusivas: rodaram ok, falharam, fora do schedule, anomalia.
 7. Se uma DAG falhou e depois teve rerun com sucesso, reportar como ruido historico salvo se houver impacto restante.
 8. Nao executar restart, rerun, retry, unpause, backfill, deploy ou alteracao em servico sem pedido explicito do usuario.
 9. Se houver acao corretiva recomendada, listar como HITL: `acao sugerida`, `risco`, `comando aproximado` quando seguro.
 10. Resposta para Telegram deve ficar abaixo de 4000 caracteres quando possivel.
+
+## Comandos base read-only
+
+```bash
+# Import errors
+gcloud compute ssh pulso-live-airflow \
+  --project=felhen-pulso-live-prod \
+  --zone=southamerica-east1-b \
+  --tunnel-through-iap \
+  --command "docker exec airflow_airflow-apiserver_1 airflow dags list-import-errors"
+
+# Lista de DAGs
+gcloud compute ssh pulso-live-airflow \
+  --project=felhen-pulso-live-prod \
+  --zone=southamerica-east1-b \
+  --tunnel-through-iap \
+  --command "docker exec airflow_airflow-scheduler_1 airflow dags list"
+
+# DagRuns running/queued direto no metastore via Airflow session
+gcloud compute ssh pulso-live-airflow \
+  --project=felhen-pulso-live-prod \
+  --zone=southamerica-east1-b \
+  --tunnel-through-iap \
+  --command "docker exec -i airflow_airflow-scheduler_1 python - <<'PY'
+from airflow.models.dagrun import DagRun
+from airflow.utils.session import create_session
+with create_session() as session:
+    rows = session.query(DagRun.dag_id, DagRun.run_id, DagRun.state, DagRun.start_date).order_by(DagRun.start_date.desc()).limit(30).all()
+for row in rows:
+    print('\\t'.join(str(x) for x in row))
+PY"
+```
 
 ## Formato de resposta
 

--- a/packages/daemon/src/routes/company-brain.ts
+++ b/packages/daemon/src/routes/company-brain.ts
@@ -23719,14 +23719,17 @@ function buildAgentRoutePrompt(args: {
           "",
           "Operational skill: operations.pulso_dags",
           `Skill docs: ${skill.docsPath}`,
-          "Pulso local skill to reuse when present: .claude/skills/dag-check.md",
+          "Pulso local skill to reuse when current: .claude/skills/dag-check.md",
           "Pulso DAG rules:",
+          "0. Live Pulso Airflow is on GCP: pulso-live-airflow in project felhen-pulso-live-prod, zone southamerica-east1-b. VM200/airflow-200 is legacy cold rollback and must not be used to determine current production DAG status.",
           "1. Verify scheduled DAG health using the Pulso checkout context, Airflow metadata/API and docs/architecture/etl-flow.md.",
           "2. Separate execution status, structural timeout/error, output freshness/volume and customer impact.",
           "3. Classify active DAGs into mutually exclusive categories: ran ok, failed, outside schedule, anomaly. Do not report generic success ratios that include DAGs outside today's schedule.",
           "4. If failures have later successful reruns, report them as historical noise unless there is remaining business impact.",
           "5. List corrective actions only. Do not rerun, restart, unpause or backfill unless the user explicitly asks.",
-          "6. Keep the Telegram answer under 4000 characters when possible.",
+          "6. Prefer gcloud compute ssh pulso-live-airflow --project=felhen-pulso-live-prod --zone=southamerica-east1-b --tunnel-through-iap for live Airflow checks; use pulso-live-clickhouse for destination-table freshness.",
+          "7. If local docs or skills mention VM200, postgres-201 metastore or airflow-200 as production, treat that as stale context and say so.",
+          "8. Keep the Telegram answer under 4000 characters when possible.",
         ]
       : [];
 


### PR DESCRIPTION
## Summary
- update the AIOS operations.pulso_dags prompt to treat VM200/airflow-200 as legacy rollback context
- document pulso-live-airflow GCP as the current source of truth for Pulso DAG checks
- add read-only GCP command examples for Airflow checks

## Validation
- npx turbo build --filter=@aios/shared --filter=@aios/daemon --force
- local agent-routing smoke confirms prompt contains pulso-live-airflow and blocks VM200 as production source