### PR TITLE
Document fresh sessions for AIOS Telegram fallback

### DIFF
--- a/docs/action/aios-operational-agent-bot-inventory-2026-05-13.md
+++ b/docs/action/aios-operational-agent-bot-inventory-2026-05-13.md
@@ -154,6 +154,9 @@ Correcao posterior deste corte:
 - uma mensagem normal como `As DAGs de hoje rodaram ok?` no bot estrategista nao deve mais cair no contexto legado `corp`;
 - o gateway detecta sinais claros de DAG/Airflow/DEG, chama o pipeline AIOS e recebe `operations.pulso_dags` + `pulsoonline-backend` do daemon;
 - a deteccao local e apenas um gatilho de entrada; skill, cwd, prompt e bloqueio de risco continuam resolvidos pelo AIOS.
+- fallback AIOS operacional passa a forcar sessao Claude nova. Isso evita que
+  `--continue` reutilize um diagnostico stale, por exemplo a conclusao antiga
+  de que VM200/`airflow-200` era o Airflow produtivo.
 
 ## AIOS Company Brain - estado vivo
 

--- a/docs/action/aios-telegram-command-layer-v0-2026-05-13.md
+++ b/docs/action/aios-telegram-command-layer-v0-2026-05-13.md
@@ -202,6 +202,7 @@ Implementacao:
 - Hash apos roteamento de cwd: `da969e142800b2759b067c2f842a8c2d5186bd8dc93e6c04987e20d2fb93897e`; backup anterior em `/home/claude/telegram-bot.py.bak-20260513-routed-cwd-f817fa33d822bdd4c0f53bb0770f1d9bb889bb9cfade5e050563ed6c2ae1cbfb`.
 - Evolucao atual: roteamento de fallback saiu do bot e entrou no daemon em `POST /api/company-brain/agent-routing/resolve`. A skill `operations.pulso_dags` agora e resolvida no AIOS com cwd, prompt e politica de memoria compartilhados entre Telegram e MCP/Codex.
 - Correcao posterior: mensagens normais que mencionam claramente DAGs/Airflow/DEG agora tambem entram no pipeline AIOS. Isso evita que o bot estrategista rode no cwd `corp` e responda que nao sabe onde procurar.
+- Correcao posterior: fallback AIOS passa a iniciar uma sessao Claude nova em vez de usar `--continue`, para nao carregar conclusoes stale de uma investigacao operacional anterior no mesmo workspace.
 
 Teste executado:
 


### PR DESCRIPTION
## Summary
- document that AIOS-routed Telegram fallbacks start a fresh Claude session
- record the stale-context failure mode from --continue for operational checks

## Validation
- live CT165 script py_compile
- monkeypatched bot smoke confirmed DAG route prompt includes pulso-live-airflow and force_new=true
- Telegram services restarted and active