### PR TITLE
Add Operating Pack Registry

### DIFF
--- a/docs/action/aios-operating-pack-registry-v0-2026-05-20.md
+++ b/docs/action/aios-operating-pack-registry-v0-2026-05-20.md
@@ -1,0 +1,43 @@
+# AIOS Operating Pack Registry v0
+
+## Decisao
+
+O AIOS passa a tratar Operating Packs como objetos canonicos read-only no
+Company Brain. Um pack nao e um bot, canal ou script solto. Ele e uma rotina
+reutilizavel por area, com owner, canais, entrypoints, risk ceiling, action
+policy, memory policy, docs e metricas de sucesso.
+
+Este corte nao cria tabela nova nem editor de packs. O registry v0 e derivado em
+codigo para consolidar os packs que ja existem sem abrir uma superficie mutavel
+antes da governanca estar pronta.
+
+## Packs seedados
+
+| Pack | Area | Execucao | Policy |
+| --- | --- | --- | --- |
+| `marketing.nr1` | marketing | `operating_pack_runner` | cria artifacts apenas por promocao explicita |
+| `operations.pulso_dags` | operations | `agent_route_skill` | observe-only, sem rerun/restart/backfill |
+| `development.pr_ci` | development | `watcher_adapter` | observe-only/proposal-only para writeback |
+
+## Contrato v0
+
+- API read-only: `GET /api/company-brain/operating-packs`.
+- MCP read-only: `get_company_brain_operating_pack_registry`.
+- UI: card `Operating Pack Registry` em `/company-brain/operating`.
+- Nenhum novo writeback externo.
+- Nenhum novo segredo.
+- Nenhuma tabela nova.
+- Canais como Telegram, MCP e web continuam transporte. A orquestracao fica no
+  AIOS: area, blueprint, source, artifact, guidance, work item, proposal e agent
+  run.
+
+## Proximo corte natural
+
+1. Ligar Command Router e Agent Routing Resolver ao registry em vez de manter
+   matches hardcoded por pack.
+2. Adicionar health por pack: ultimo uso, ultimo artifact, ultimo erro e guidance
+   aberta.
+3. Promover o registry para schema persistente apenas quando houver necessidade
+   real de criar/pausar/versionar packs pela UI.
+4. Definir review flow para pack novo: docs -> preview -> policy -> dogfood ->
+   active.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -57,6 +57,8 @@ Status AgentContext Daily Handoff v0 em 2026-05-06: gerador interno/read-only im
 
 Status Design Partner Operating Pack v0 em 2026-05-06: pacote documental reproduzivel criado em `docs/company-brain-design-partner-operating-pack.md`, consolidando demo seed, operating cadence, gate closure, daily handoff, roteiro de demo, fronteiras de dados, reset e criterios de aceite. Sem codigo novo e sem mutacao externa.
 
+Status Operating Pack Registry v0 em 2026-05-20: registry canonico/read-only criado para expor packs aprovados por area, canal, entrypoint, policy, risk ceiling e memoria. Seeds iniciais: `marketing.nr1`, `operations.pulso_dags` e `development.pr_ci`. API `GET /api/company-brain/operating-packs`, MCP `get_company_brain_operating_pack_registry` e bloco na UI `/company-brain/operating`. Sem tabela nova, sem editor de packs e sem nova mutacao externa.
+
 Status Review Cohesion v0 em 2026-05-06: fila unificada derivada para Decision/Signal/AlignmentFinding/Guidance candidates implementada em summary/API/UI/MCP. O corte mostra decisions propostas, signals sem finding, findings sem guidance e guidance aberta com feedback pendente, com next action, severity, provenance e acoes internas de review/extracao/feedback. Sem writeback externo.
 
 Status Writeback Governance v0 em 2026-05-06: politica A/B/C de `risk_class` + `action_policy` implementada com fila interna `ExternalActionProposal`, geracao a partir de `GuidanceItem` aceito, approve/reject por HITL, execution status e audit trail completo em API/UI/MCP. Slack/GitHub writeback real permanece bloqueado; aprovar proposta nao executa mutacao externa.

--- a/docs/company-brain-direction.md
+++ b/docs/company-brain-direction.md
@@ -31,6 +31,7 @@ O alvo agora adiciona:
 - Drift Inbox;
 - Guidance Engine;
 - Workflow Blueprint Engine;
+- Operating Pack Registry;
 - Work Management Layer;
 - Agent Context Generator;
 - AutoImprove UI/API.
@@ -60,6 +61,7 @@ O core deste repo precisa sustentar operacao multi-area com estado e provenance:
 | Company Brain/Graph | Estrategia, metas, decisoes, owners, work items, artifacts, signals e proposals. |
 | Goal/Cadence | Metas, prazos, milestones, metricas, review cadence e SLA status. |
 | Workflow Orchestration | Blueprints/runs/gates por area. |
+| Operating Pack Registry | Rotinas reutilizaveis por area com owner, canais, policy, entrypoints e metricas de sucesso. |
 | Agent Runtime | Agentes executando etapas sob gates e policies. |
 | Governance/Policy | Risco A/B/C, HITL, rollback, tenant/source visibility, retention e write permissions. |
 | Context/Retrieval | QMD, search, embeddings e memory. |
@@ -129,6 +131,7 @@ Se uma feature so ingere informacao e nao ajuda a fechar o loop, ela e suporte, 
 | UI | `packages/web/src/app/` | Criar telas de Strategy Map, Evidence Inbox, Drift Inbox, Workflow Runs e Guidance. |
 | MCP | `packages/mcp-server/src/index.ts` | Expor ferramentas para agentes criarem/lerem artifacts, work items, workflow runs e guidance. |
 | Auth/tenancy | `packages/daemon/src/middleware/` e `docs/auth-rollout.md` | Preservar CF Access e preparar separacao de fonte/tenant antes de qualquer piloto externo. |
+| Operating Packs | `packages/daemon/src/routes/company-brain.ts` | Expor registry read-only de packs aprovados antes de permitir criacao/edicao em UI. |
 
 ## Primeiro slice recomendado
 
@@ -146,6 +149,7 @@ Se uma feature so ingere informacao e nao ajuda a fechar o loop, ela e suporte, 
 9. Gerar o primeiro `WorkflowRun` real a partir de um ticket pequeno deste repo ou do dogfood ERP.
 10. Registrar failures/residuais como novos signals ou work items.
 11. Fazer o fechamento do run atualizar docs oficiais.
+12. Registrar packs operacionais aprovados como registry read-only antes de transformar canais em bots ou scripts paralelos.
 
 ## O que nao fazer agora
 

--- a/packages/daemon/src/routes/company-brain.ts
+++ b/packages/daemon/src/routes/company-brain.ts
@@ -164,6 +164,8 @@ import type {
   CompanyBrainAgentRouteResponse,
   CompanyBrainOperatingPackAction,
   CompanyBrainOperatingPackArtifactRef,
+  CompanyBrainOperatingPackRegistry,
+  CompanyBrainOperatingPackRegistryEntry,
   CompanyBrainOperatingPackMemoryPolicy,
   CompanyBrainOperatingPackRunResponse,
   CompanyBrainOperatingPackSlug,
@@ -22947,6 +22949,178 @@ app.post("/command-router", async (c) => {
 const MARKETING_NR1_DEFAULT_SEGMENT =
   "contabilidades e consultorias que atendem empresas de 50-500 colaboradores";
 
+const OPERATING_PACK_REGISTRY_ENTRIES: CompanyBrainOperatingPackRegistryEntry[] = [
+  {
+    slug: "marketing.nr1",
+    title: "Spa da Vida NR-1 marketing pack",
+    area: "marketing",
+    status: "active",
+    owner: "Felhen Marketing",
+    ownerType: "team",
+    summary:
+      "Daily commercial briefing, explicit memory promotion and HITL feedback for Spa da Vida Empresas / NR-1 demand generation.",
+    docsPath: "docs/action/aios-marketing-operating-pack-v0-2026-05-13.md",
+    executionMode: "operating_pack_runner",
+    entrypoints: [
+      {
+        kind: "api",
+        label: "Run pack",
+        path: "/api/company-brain/operating-packs/run",
+      },
+    ],
+    channels: ["telegram", "web", "mcp"],
+    capabilities: ["briefing", "explicit_promotion", "hitl_feedback"],
+    sourceRefs: ["telegram://aios-bots", "aios://operating-packs/marketing/nr1"],
+    workflowBlueprintIds: ["marketing-operating-pack-v0"],
+    watcherIds: [],
+    maxRiskClass: "B",
+    actionPolicy: "create_artifacts",
+    memoryPolicy: "ephemeral",
+    externalWritePolicy: "none",
+    successMetrics: [
+      "useful briefing returned without opening Codex",
+      "strategic learnings promoted only by explicit command",
+      "feedback creates reusable evidence when an artifact is promoted",
+    ],
+    promotionPolicy:
+      "Briefings are ephemeral by default; promoted artifacts require explicit human reason and feedback.",
+    statusNote:
+      "Live runner exists in the daemon; Telegram is only a gateway and does not own pack logic.",
+  },
+  {
+    slug: "operations.pulso_dags",
+    title: "PulsoOnline DAG health check skill",
+    area: "operations",
+    status: "active",
+    owner: "Felhen Operations",
+    ownerType: "team",
+    summary:
+      "Read-only Airflow DAG health triage for PulsoOnline with current GCP Airflow routing, stale-context guardrails and no rerun/restart side effects.",
+    docsPath: "docs/action/aios-operations-pulso-dags-pack-v0-2026-05-13.md",
+    executionMode: "agent_route_skill",
+    entrypoints: [
+      {
+        kind: "api",
+        label: "Resolve route",
+        path: "/api/company-brain/agent-routing/resolve",
+      },
+      {
+        kind: "mcp",
+        label: "Resolve via MCP",
+        mcpTool: "resolve_company_brain_agent_route",
+      },
+    ],
+    channels: ["telegram", "mcp"],
+    capabilities: ["read_only_triage", "stale_context_guard", "agent_prompt_generation"],
+    sourceRefs: ["gcp://felhen-pulso-live-prod/pulso-live-airflow"],
+    workflowBlueprintIds: ["operations-read-only-triage-v0"],
+    watcherIds: [],
+    maxRiskClass: "B",
+    actionPolicy: "observe_only",
+    memoryPolicy: "ephemeral",
+    externalWritePolicy: "none",
+    successMetrics: [
+      "route lands in pulsoonline-backend context",
+      "answer separates execution status from output freshness and business impact",
+      "no rerun, restart, unpause or backfill without explicit HITL",
+    ],
+    promotionPolicy:
+      "Only repeated operational findings or accepted incident learnings become Company Brain evidence.",
+    statusNote:
+      "Implemented as an operational skill resolved by agent-routing; no direct daemon executor yet.",
+  },
+  {
+    slug: "development.pr_ci",
+    title: "Development PR/CI operating pack",
+    area: "development",
+    status: "active",
+    owner: "Felhen Platform",
+    ownerType: "team",
+    summary:
+      "PR/CI watcher and review intake loop for AIOS development work: observe PRs, checks, reviews and stale gates before agent execution.",
+    docsPath: "docs/action/company-brain-production-operating-loop-2026-05-07.md",
+    executionMode: "watcher_adapter",
+    entrypoints: [
+      {
+        kind: "watcher",
+        label: "PR/CI watcher",
+        watcherId: "watcher-github-pr-ci-v0",
+      },
+      {
+        kind: "api",
+        label: "Sync PR/CI",
+        path: "/api/company-brain/adapters/github/pr-ci/sync",
+      },
+      {
+        kind: "api",
+        label: "Sync AIOS-authored PR reviews",
+        path: "/api/company-brain/adapters/github/aios-pr-reviews/sync",
+      },
+    ],
+    channels: ["web", "mcp", "operating_loop"],
+    capabilities: ["pr_ci_observation", "review_intake", "guidance_generation"],
+    sourceRefs: ["github://antonio-mello-ai/crewdock"],
+    workflowBlueprintIds: ["development-blueprint-v0"],
+    watcherIds: ["watcher-github-pr-ci-v0", "watcher-github-notifications-v0"],
+    maxRiskClass: "B",
+    actionPolicy: "observe_only",
+    memoryPolicy: "promote_recommended",
+    externalWritePolicy: "proposal_only",
+    successMetrics: [
+      "PR/CI state creates artifacts and signals",
+      "AIOS-authored PR review state returns to Company Brain",
+      "writeback remains proposal or approved path only",
+    ],
+    promotionPolicy:
+      "Execution learnings should become guidance or ImprovementProposal only after evidence packet review.",
+    statusNote:
+      "Backed by existing watchers and adapters; no new external write path in this registry slice.",
+  },
+];
+
+function buildOperatingPackRegistry(timestamp = now()): CompanyBrainOperatingPackRegistry {
+  const totals: CompanyBrainOperatingPackRegistry["totals"] = {
+    entryCount: OPERATING_PACK_REGISTRY_ENTRIES.length,
+    activeCount: 0,
+    draftCount: 0,
+    pausedCount: 0,
+    archivedCount: 0,
+    operatingPackRunnerCount: 0,
+    agentRouteSkillCount: 0,
+    watcherAdapterCount: 0,
+    noExternalWriteCount: 0,
+    proposalOnlyCount: 0,
+    approvedWritebackCount: 0,
+  };
+
+  for (const entry of OPERATING_PACK_REGISTRY_ENTRIES) {
+    if (entry.status === "active") totals.activeCount += 1;
+    if (entry.status === "draft") totals.draftCount += 1;
+    if (entry.status === "paused") totals.pausedCount += 1;
+    if (entry.status === "archived") totals.archivedCount += 1;
+    if (entry.executionMode === "operating_pack_runner") {
+      totals.operatingPackRunnerCount += 1;
+    }
+    if (entry.executionMode === "agent_route_skill") {
+      totals.agentRouteSkillCount += 1;
+    }
+    if (entry.executionMode === "watcher_adapter") {
+      totals.watcherAdapterCount += 1;
+    }
+    if (entry.externalWritePolicy === "none") totals.noExternalWriteCount += 1;
+    if (entry.externalWritePolicy === "proposal_only") totals.proposalOnlyCount += 1;
+    if (entry.externalWritePolicy === "approved_writeback") {
+      totals.approvedWritebackCount += 1;
+    }
+  }
+
+  return {
+    generatedAt: timestamp,
+    entries: OPERATING_PACK_REGISTRY_ENTRIES,
+    totals,
+  };
+}
+
 function normalizeOperatingPackMatchText(value: string): string {
   return value
     .normalize("NFD")
@@ -23589,7 +23763,7 @@ app.post("/operating-packs/run", async (c) => {
       request,
       router,
       handled: false,
-      packSlug: null,
+      packSlug,
       action,
       responseText: formatCommandRouterPreview(router),
       memoryPolicy: "ephemeral",
@@ -23600,6 +23774,10 @@ app.post("/operating-packs/run", async (c) => {
     const message = err instanceof Error ? err.message : "Unknown error";
     return c.json({ error: "operating_pack_run_failed", message }, 400);
   }
+});
+
+app.get("/operating-packs", (c) => {
+  return c.json({ data: buildOperatingPackRegistry() });
 });
 
 const PULSO_DAGS_SKILL_DOCS_PATH =

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -2606,6 +2606,22 @@ server.registerTool(
 );
 
 server.registerTool(
+  "get_company_brain_operating_pack_registry",
+  {
+    title: "Get Company Brain Operating Pack Registry",
+    description:
+      "Read-only registry of approved AIOS Operating Packs and operational skills by area, channel, policy, entrypoint, risk ceiling and memory rules. Use this before routing pack-like requests so channels do not become separate orchestration layers.",
+    inputSchema: {},
+  },
+  async () => {
+    const result = await daemonFetch<{ data: unknown }>(
+      "/api/company-brain/operating-packs"
+    );
+    return formatJsonResult(result.data);
+  }
+);
+
+server.registerTool(
   "resolve_company_brain_agent_route",
   {
     title: "Resolve Company Brain agent route",

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -4227,13 +4227,81 @@ export interface CompanyBrainCommandRouterResult {
   routing: CommandRouterRouting;
 }
 
-export type CompanyBrainOperatingPackSlug = "marketing.nr1";
+export type CompanyBrainOperatingPackSlug =
+  | "marketing.nr1"
+  | "operations.pulso_dags"
+  | "development.pr_ci";
 export type CompanyBrainOperatingPackAction = "run" | "promote" | "feedback";
 export type CompanyBrainOperatingPackMemoryPolicy =
   | "ephemeral"
   | "promote_recommended"
   | "promote_required"
   | "promoted";
+export type CompanyBrainOperatingPackStatus =
+  | "active"
+  | "draft"
+  | "paused"
+  | "archived";
+export type CompanyBrainOperatingPackExecutionMode =
+  | "operating_pack_runner"
+  | "agent_route_skill"
+  | "watcher_adapter";
+export type CompanyBrainOperatingPackEntrypointKind =
+  | "api"
+  | "mcp"
+  | "watcher"
+  | "agent_route";
+
+export interface CompanyBrainOperatingPackEntrypoint {
+  kind: CompanyBrainOperatingPackEntrypointKind;
+  label: string;
+  path?: string | null;
+  mcpTool?: string | null;
+  watcherId?: string | null;
+}
+
+export interface CompanyBrainOperatingPackRegistryEntry {
+  slug: CompanyBrainOperatingPackSlug;
+  title: string;
+  area: CompanyBrainArea;
+  status: CompanyBrainOperatingPackStatus;
+  owner: string;
+  ownerType: OwnerType;
+  summary: string;
+  docsPath: string;
+  executionMode: CompanyBrainOperatingPackExecutionMode;
+  entrypoints: CompanyBrainOperatingPackEntrypoint[];
+  channels: string[];
+  capabilities: string[];
+  sourceRefs: string[];
+  workflowBlueprintIds: string[];
+  watcherIds: string[];
+  maxRiskClass: RiskClass;
+  actionPolicy: ActionPolicy;
+  memoryPolicy: CompanyBrainOperatingPackMemoryPolicy;
+  externalWritePolicy: "none" | "proposal_only" | "approved_writeback";
+  successMetrics: string[];
+  promotionPolicy: string;
+  statusNote: string;
+}
+
+export interface CompanyBrainOperatingPackRegistry {
+  generatedAt: number;
+  entries: CompanyBrainOperatingPackRegistryEntry[];
+  totals: {
+    entryCount: number;
+    activeCount: number;
+    draftCount: number;
+    pausedCount: number;
+    archivedCount: number;
+    operatingPackRunnerCount: number;
+    agentRouteSkillCount: number;
+    watcherAdapterCount: number;
+    noExternalWriteCount: number;
+    proposalOnlyCount: number;
+    approvedWritebackCount: number;
+  };
+}
 
 export interface RunCompanyBrainOperatingPackRequest {
   text: string;

--- a/packages/web/src/app/company-brain/operating/page.tsx
+++ b/packages/web/src/app/company-brain/operating/page.tsx
@@ -18,6 +18,7 @@ import {
 } from "lucide-react";
 import {
   useCompanyBrainAiosPrReviewIntake,
+  useCompanyBrainOperatingPackRegistry,
   useCompanyBrainOperatingSnapshot,
   useGenerateCompanyBrainDailyAgentHandoff,
   useRunCompanyBrainOperatingCadence,
@@ -28,6 +29,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { formatTimeAgo } from "@/lib/utils";
 import type {
+  CompanyBrainOperatingPackRegistryEntry,
   CompanyBrainOperatingSnapshotCard,
   CompanyBrainOperatingSnapshotCardKey,
 } from "@aios/shared";
@@ -57,6 +59,7 @@ function formatTimestamp(value: number | null) {
 
 export default function CompanyBrainOperatingPage() {
   const { data, isLoading } = useCompanyBrainOperatingSnapshot();
+  const { data: operatingPackRegistryData } = useCompanyBrainOperatingPackRegistry();
   const { data: prReviewData } = useCompanyBrainAiosPrReviewIntake();
   const runCadence = useRunCompanyBrainOperatingCadence();
   const runWatcher = useRunCompanyBrainWatcher();
@@ -67,6 +70,7 @@ export default function CompanyBrainOperatingPage() {
   const [nextWorkCopyState, setNextWorkCopyState] = useState<"idle" | "copied" | "failed">("idle");
 
   const snapshot = data?.data;
+  const operatingPackRegistry = operatingPackRegistryData?.data;
   const prReviewIntake = prReviewData?.data;
   const pendingPrReviews =
     prReviewIntake?.items.filter((item) =>
@@ -448,6 +452,104 @@ export default function CompanyBrainOperatingPage() {
                 </article>
               );
             })}
+          </div>
+        </section>
+
+        <section className="rounded-md border border-border p-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <div className="flex items-center gap-2">
+                <Brain className="size-4 text-muted-foreground" />
+                <h2 className="text-lg font-semibold">Operating Pack Registry</h2>
+                {operatingPackRegistry ? (
+                  <Badge variant="outline">
+                    {operatingPackRegistry.totals.activeCount} active
+                  </Badge>
+                ) : null}
+              </div>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Approved reusable routines by area, channel, policy and entrypoint.
+              </p>
+            </div>
+            {operatingPackRegistry ? (
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="outline">
+                  {operatingPackRegistry.totals.entryCount} packs
+                </Badge>
+                <Badge variant="outline">
+                  {operatingPackRegistry.totals.noExternalWriteCount} no write
+                </Badge>
+                <Badge variant="outline">
+                  {operatingPackRegistry.totals.proposalOnlyCount} proposal-only
+                </Badge>
+              </div>
+            ) : null}
+          </div>
+
+          <div className="mt-4 grid gap-3 lg:grid-cols-3">
+            {(operatingPackRegistry?.entries ?? []).map(
+              (entry: CompanyBrainOperatingPackRegistryEntry) => (
+                <article key={entry.slug} className="rounded-md border border-border p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <h3 className="truncate text-sm font-semibold">{entry.title}</h3>
+                      <p className="mt-1 text-xs text-muted-foreground">{entry.slug}</p>
+                    </div>
+                    <Badge variant={stateVariant(entry.status)}>{entry.status}</Badge>
+                  </div>
+
+                  <p className="mt-3 min-h-16 text-sm text-muted-foreground">
+                    {entry.summary}
+                  </p>
+
+                  <div className="mt-4 flex flex-wrap gap-1.5 text-xs">
+                    <Badge variant="outline">{entry.area}</Badge>
+                    <Badge variant="outline">{entry.executionMode}</Badge>
+                    <Badge variant="outline">Risk {entry.maxRiskClass}</Badge>
+                    <Badge variant="outline">{entry.actionPolicy}</Badge>
+                    <Badge variant="outline">{entry.externalWritePolicy}</Badge>
+                  </div>
+
+                  <div className="mt-4 space-y-3 text-xs">
+                    <div>
+                      <div className="font-semibold text-muted-foreground">Channels</div>
+                      <div className="mt-1 flex flex-wrap gap-1">
+                        {entry.channels.map((channel) => (
+                          <Badge key={channel} variant="secondary">
+                            {channel}
+                          </Badge>
+                        ))}
+                      </div>
+                    </div>
+
+                    <div>
+                      <div className="font-semibold text-muted-foreground">Entrypoints</div>
+                      <div className="mt-1 space-y-1">
+                        {entry.entrypoints.map((entrypoint) => (
+                          <div
+                            key={`${entry.slug}-${entrypoint.kind}-${entrypoint.label}`}
+                            className="rounded border border-border bg-muted/30 px-2 py-1"
+                          >
+                            <span className="font-medium">{entrypoint.label}</span>
+                            <span className="mx-1 text-muted-foreground">/</span>
+                            <span className="break-all text-muted-foreground">
+                              {entrypoint.path ??
+                                entrypoint.mcpTool ??
+                                entrypoint.watcherId ??
+                                entrypoint.kind}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="mt-4 border-t border-border pt-3 text-xs text-muted-foreground">
+                    {entry.statusNote}
+                  </div>
+                </article>
+              )
+            )}
           </div>
         </section>
 

--- a/packages/web/src/hooks/use-api.ts
+++ b/packages/web/src/hooks/use-api.ts
@@ -25,6 +25,7 @@ import type {
   CompanyBrainWritebackAuditTrailResponse,
   CompanyBrainWritebackEvidenceIntegrityGapsResponse,
   CompanyBrainWritebackEvidenceRemediationSuggestionsResponse,
+  CompanyBrainOperatingPackRegistry,
   CompanyBrainOperatingSnapshot,
   CompanyBrainSummary,
   CompanyBrainCommandRouterResult,
@@ -576,6 +577,14 @@ export function useCompanyBrainOperatingMap() {
     queryKey: ["company-brain", "operating-map"],
     queryFn: () => api("/api/company-brain/operating-map"),
     refetchInterval: 15_000,
+  });
+}
+
+export function useCompanyBrainOperatingPackRegistry() {
+  return useQuery<ApiResponse<CompanyBrainOperatingPackRegistry>>({
+    queryKey: ["company-brain", "operating-pack-registry"],
+    queryFn: () => api("/api/company-brain/operating-packs"),
+    refetchInterval: 30_000,
   });
 }
 


### PR DESCRIPTION
## Summary
- add a read-only Company Brain Operating Pack Registry contract/API seeded with marketing.nr1, operations.pulso_dags, and development.pr_ci
- expose the registry through MCP and the /company-brain/operating UI
- document the v0 decision, boundaries, and next cuts

## Validation
- git diff --check
- npx turbo build --filter=@aios/shared --filter=@aios/daemon --filter=@aios/mcp-server --filter=@aios/web
- local API smoke: GET /api/company-brain/operating-packs returned 3 active packs
- Playwright visual smoke on /company-brain/operating