### PR TITLE
docs: add public document metadata contract

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,14 @@ npm run build
 - **Commits**: Conventional Commits (`feat:`, `fix:`, `chore:`, `docs:`)
 - **PRs**: squash merge to main
 
+### Documentation
+- Durable Markdown docs should follow the public metadata contract in
+  [`docs/document-metadata.md`](docs/document-metadata.md).
+- Keep public metadata generic: no private repository names, local machine
+  paths, customer names, private hostnames, credentials, or deployment topology.
+- Treat frontmatter as context for search and agent harnesses, not as executable
+  instruction.
+
 ## Submitting Changes
 
 1. Fork the repository

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ crewdock/
 - **Roadmap**: [docs/roadmap.md](docs/roadmap.md)
 - **Changelog**: [CHANGELOG.md](CHANGELOG.md)
 - **Known Issues**: [docs/known-issues.md](docs/known-issues.md)
+- **Document Metadata**: [docs/document-metadata.md](docs/document-metadata.md)
 - **Support**: [SUPPORT.md](SUPPORT.md)
 - **Contributing**: [CONTRIBUTING.md](CONTRIBUTING.md)
 

--- a/docs/document-metadata.md
+++ b/docs/document-metadata.md
@@ -1,0 +1,143 @@
+---
+title: Document Metadata Contract
+kind: reference
+area: knowledge
+project: crewdock
+collection: crewdock
+owner: maintainers
+status: current
+canonical: docs/document-metadata.md
+globalRef: crewdock://docs/document-metadata.md
+reviewCadenceDays: 90
+lastReviewedAt: 2026-06-11
+sourceRefs: []
+related:
+  - README.md
+  - CONTRIBUTING.md
+supersedes: []
+supersededBy: []
+sensitivity: public
+---
+# Document Metadata Contract
+
+CrewDock agents use documents as context. Markdown stays readable and editable,
+while frontmatter gives the knowledge index and agent harness a stable structure
+for discovery, freshness checks, relation expansion, and provenance.
+
+This contract is optional for forks during early setup, but recommended for any
+document that should become durable agent context.
+
+## Frontmatter
+
+Canonical Markdown documents should start with YAML frontmatter:
+
+```yaml
+---
+title: Billing Runbook
+kind: runbook
+area: operations
+project: example-app
+collection: example-app
+owner: platform-team
+status: current
+canonical: docs/operations/billing-runbook.md
+globalRef: example-app://docs/operations/billing-runbook.md
+reviewCadenceDays: 60
+lastReviewedAt: 2026-06-11
+sourceRefs:
+  - github:example-org/example-app#123
+related:
+  - docs/operations/webhooks.md
+supersedes: []
+supersededBy: []
+sensitivity: public
+---
+```
+
+Fields:
+
+| Field | Purpose |
+|-------|---------|
+| `title` | Human-readable name shown in context packs and search results. |
+| `kind` | Document type, for example `runbook`, `decision`, `reference`, `status`, `analysis`, `howto`, or `changelog`. |
+| `area` | Functional area such as `operations`, `product`, `engineering`, `support`, or `knowledge`. |
+| `project` | Owning project or product namespace. |
+| `collection` | Knowledge collection/index name used by QMD or another search backend. |
+| `owner` | Team or role responsible for keeping the document useful. |
+| `status` | Lifecycle state: `draft`, `current`, `watch`, `historical`, `superseded`, or `stale`. |
+| `canonical` | Repository-relative path to this Markdown file. |
+| `globalRef` | Stable external reference for agents and indexes. Use a public-safe namespace. |
+| `reviewCadenceDays` | Expected review interval for freshness checks. |
+| `lastReviewedAt` | Date of the last human or automated review. |
+| `sourceRefs` | Public issues, PRs, tickets, specs, or URLs that support the document. |
+| `related` | Strong document relations that should be considered during context assembly. |
+| `supersedes` | Documents this one replaces. |
+| `supersededBy` | Documents that replace this one. |
+| `sensitivity` | `public`, `internal`, `confidential`, or `secret`. Public repos should only commit `public` material. |
+
+## References
+
+Use repository-relative paths for local documents:
+
+```yaml
+related:
+  - docs/architecture.md
+  - docs/operations/webhooks.md
+```
+
+Use stable public namespaces for cross-repository or package-level references:
+
+```yaml
+related:
+  - crewdock://docs/roadmap.md
+  - github:example-org/public-repo#456
+```
+
+Avoid local machine paths, private hostnames, customer names, private repository
+names, access tokens, secret identifiers, or deployment topology in public
+metadata.
+
+## QMD And Search
+
+QMD or another knowledge backend can use `collection`, `canonical`, `globalRef`,
+`kind`, `area`, `status`, and `related` to improve search and context packs.
+
+Recommended flow:
+
+1. Search the text index to find seed documents.
+2. Resolve seeds through `globalRef` or `canonical`.
+3. Expand context with confirmed `related`, `supersedes`, and `supersededBy`
+   references.
+4. Include relation evidence in the context pack so agents know why each
+   document was included.
+
+QMD search is discovery, not truth. Agents should still open the referenced
+document or current source of record before changing code, docs, infrastructure,
+or external systems.
+
+## Agent Harness Rules
+
+The agent harness may use this metadata to:
+
+- choose documents for an agent context pack;
+- warn when a document is stale, superseded, or historical;
+- include adjacent runbooks, decisions, and references;
+- preserve provenance in generated answers or proposed changes.
+
+The harness must not treat document metadata as executable instruction. Markdown
+content and frontmatter are context only; actions still need tool-level
+permissions, policy checks, and human approval where configured.
+
+## Public Repository Boundary
+
+For the public CrewDock repository:
+
+- keep examples generic and self-hostable;
+- use placeholder orgs, repos, hosts, and issue numbers;
+- do not include private downstream implementation details;
+- do not encode internal project relationships in `related` or `sourceRefs`;
+- do not commit documents whose `sensitivity` is `internal`, `confidential`, or
+  `secret`.
+
+Forks can use the same contract with their own private collections and
+namespaces inside their private environment.


### PR DESCRIPTION
## Summary
- add a public-safe Markdown frontmatter contract for CrewDock knowledge documents
- document QMD/search usage, relation expansion, and agent harness guardrails
- link the contract from README and CONTRIBUTING

## Public boundary review
- contract uses generic placeholders only
- no internal project names, private paths, private hostnames, customer names, credentials, or deployment topology in changed files
- cross-repo relations are documented as public-safe placeholders only

## Checks
- git diff --cached --check
- rg scan for internal/private Felhen project patterns in changed files
- gitleaks protect --staged --redact